### PR TITLE
fix(core/serve): Finish now should stop the solver even if the next solution will take a lot of time to produce.

### DIFF
--- a/core/nurse_scheduling/solver_ortools_cp_sat.py
+++ b/core/nurse_scheduling/solver_ortools_cp_sat.py
@@ -20,6 +20,7 @@
 import logging
 import threading
 from collections.abc import Callable
+from _thread import LockType
 from typing import Any
 from ortools.sat.python import cp_model
 
@@ -244,7 +245,7 @@ class ORToolsSolver(SolverInterface):
         solution_callback: Callable[[Any], None] | None = None,
         progress_callback: Callable[[SolverProgress], None] | None = None,
         should_stop: Callable[[], bool] | None = None,
-        should_stop_lock=None,
+        should_stop_lock: LockType | None = None,
     ) -> Any:
         """Create a solution callback for tracking intermediate solutions."""
         import time

--- a/core/nurse_scheduling/solver_ortools_cp_sat.py
+++ b/core/nurse_scheduling/solver_ortools_cp_sat.py
@@ -116,11 +116,13 @@ class ORToolsSolver(SolverInterface):
                     exc,
                 )
 
+        should_stop_lock = threading.Lock() if should_stop is not None else None
         internal_solution_callback = self.create_solution_callback(
             self.objective_expr,
             solution_callback=solution_callback,
             progress_callback=progress_callback,
             should_stop=should_stop,
+            should_stop_lock=should_stop_lock,
         )
         stop_watcher_done = threading.Event()
         stop_watcher = None
@@ -130,7 +132,8 @@ class ORToolsSolver(SolverInterface):
             def watch_stop_request():
                 while not stop_watcher_done.wait(0.2):
                     try:
-                        stop_requested = should_stop()
+                        with should_stop_lock:
+                            stop_requested = should_stop()
                     except Exception:
                         logging.exception("Stop callback failed")
                         return
@@ -241,17 +244,20 @@ class ORToolsSolver(SolverInterface):
         solution_callback: Callable[[Any], None] | None = None,
         progress_callback: Callable[[SolverProgress], None] | None = None,
         should_stop: Callable[[], bool] | None = None,
+        should_stop_lock=None,
     ) -> Any:
         """Create a solution callback for tracking intermediate solutions."""
         import time
 
+        if should_stop is not None and should_stop_lock is None:
+            should_stop_lock = threading.Lock()
         maximize = self.maximize
         solver = self
 
         class PartialSolutionPrinter(cp_model.CpSolverSolutionCallback):
             """Print intermediate solutions."""
 
-            def __init__(self, objective_var, solution_callback, progress_callback, should_stop):
+            def __init__(self, objective_var, solution_callback, progress_callback, should_stop, should_stop_lock):
                 cp_model.CpSolverSolutionCallback.__init__(self)
                 self.n_solutions = 0
                 self.best_score = float("-inf") if maximize else float("inf")
@@ -260,6 +266,7 @@ class ORToolsSolver(SolverInterface):
                 self.solution_callback = solution_callback
                 self.progress_callback = progress_callback
                 self.should_stop = should_stop
+                self.should_stop_lock = should_stop_lock
                 self.solution_index = 0
 
             def on_solution_callback(self):
@@ -299,9 +306,14 @@ class ORToolsSolver(SolverInterface):
                             self.solution_callback(self)
                         except Exception:
                             logging.exception("Solution callback failed")
-                    if self.should_stop is not None and self.should_stop():
-                        self.StopSearch()
+                    if self.should_stop is not None:
+                        with self.should_stop_lock:
+                            stop_requested = self.should_stop()
+                        if stop_requested:
+                            self.StopSearch()
                 finally:
                     solver._active_solution_callback = None
 
-        return PartialSolutionPrinter(objective_var, solution_callback, progress_callback, should_stop)
+        return PartialSolutionPrinter(
+            objective_var, solution_callback, progress_callback, should_stop, should_stop_lock
+        )

--- a/core/nurse_scheduling/solver_ortools_cp_sat.py
+++ b/core/nurse_scheduling/solver_ortools_cp_sat.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
+import threading
 from collections.abc import Callable
 from typing import Any
 from ortools.sat.python import cp_model
@@ -121,7 +122,31 @@ class ORToolsSolver(SolverInterface):
             progress_callback=progress_callback,
             should_stop=should_stop,
         )
-        self.status = self.solver.Solve(self.model, internal_solution_callback)
+        stop_watcher_done = threading.Event()
+        stop_watcher = None
+
+        if should_stop is not None:
+
+            def watch_stop_request():
+                while not stop_watcher_done.wait(0.2):
+                    try:
+                        stop_requested = should_stop()
+                    except Exception:
+                        logging.exception("Stop callback failed")
+                        return
+                    if stop_requested:
+                        self.solver.StopSearch()
+                        return
+
+            stop_watcher = threading.Thread(target=watch_stop_request, name="ortools-stop-watcher", daemon=True)
+            stop_watcher.start()
+
+        try:
+            self.status = self.solver.Solve(self.model, internal_solution_callback)
+        finally:
+            stop_watcher_done.set()
+            if stop_watcher is not None:
+                stop_watcher.join(timeout=1)
 
         # Convert OR-Tools status to our enum
         if self.status == cp_model.OPTIMAL:

--- a/core/tests/test_serve.py
+++ b/core/tests/test_serve.py
@@ -35,9 +35,11 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import pytest
 from pathlib import Path
 from fastapi.testclient import TestClient
+from ortools.sat.python import cp_model
 
 import nurse_scheduling.serve as serve
 from nurse_scheduling.solver_interface import SchedulePhaseProgress, SolverProgress
+from nurse_scheduling.solver_ortools_cp_sat import ORToolsSolver
 from nurse_scheduling.serve import app
 
 # Test client
@@ -403,6 +405,49 @@ class TestOptimizeJobs:
             f"[server:job] finish-now-requested job_id={job_id} status=running client_uuid=" in message
             for message in caplog.messages
         )
+
+    def test_optimize_job_finish_now_interrupts_ortools_search_between_solution_callbacks(self, monkeypatch):
+        class BlockingCpSolver:
+            def __init__(self):
+                self.solve_started = threading.Event()
+                self.stop_search_called = threading.Event()
+
+            def Solve(self, model, callback=None):
+                self.solve_started.set()
+                if not self.stop_search_called.wait(timeout=2):
+                    raise AssertionError("finish-now did not interrupt OR-Tools search")
+                return cp_model.FEASIBLE
+
+            def StopSearch(self):
+                self.stop_search_called.set()
+
+        blocking_solver = BlockingCpSolver()
+
+        def fake_schedule(*args, **kwargs):
+            solver = ORToolsSolver()
+            solver.set_objective(0, maximize=True)
+            solver.solver = blocking_solver
+            solver.solve(should_stop=kwargs["should_stop"])
+            return "fake_df", {}, 7, "FEASIBLE", None
+
+        def fake_export_to_excel(df, output_buffer, cell_export_info):
+            output_buffer.write(b"fake xlsx bytes")
+
+        monkeypatch.setattr(serve.scheduler, "schedule", fake_schedule)
+        monkeypatch.setattr(serve.exporter, "export_to_excel", fake_export_to_excel)
+
+        response = client.post("/optimize", data={"yaml_content": "apiVersion: alpha\n"})
+        job_id = response.json()["jobId"]
+        wait_for_job_status(job_id, "running")
+        assert blocking_solver.solve_started.wait(timeout=1)
+
+        finish_response = client.post(f"/optimize/{job_id}/finish-now")
+
+        assert finish_response.status_code == 200
+        completed = wait_for_job_status(job_id, "feasible")
+        assert blocking_solver.stop_search_called.is_set()
+        assert completed["score"] == 7
+        assert completed["xlsxReady"] is True
 
     def test_optimize_job_control_rejects_solver_without_stop_support(self):
         job = serve._create_optimize_job(

--- a/core/tests/test_solver_ortools_cp_sat.py
+++ b/core/tests/test_solver_ortools_cp_sat.py
@@ -21,6 +21,7 @@
 
 import os
 import sys
+import threading
 
 import pytest
 from ortools.sat.python import cp_model
@@ -357,3 +358,46 @@ def test_solve_always_registers_internal_solution_callback():
 
     assert status == SolverStatus.OPTIMAL
     assert isinstance(dummy_solver.callback, cp_model.CpSolverSolutionCallback)
+
+
+def test_solve_should_stop_interrupts_search_between_solution_callbacks():
+    solver = ORToolsSolver()
+    solver.set_objective(0, maximize=True)
+
+    class BlockingCpSolver:
+        def __init__(self):
+            self.callback = None
+            self.solve_started = threading.Event()
+            self.stop_search_called = threading.Event()
+
+        def Solve(self, model, callback=None):
+            self.callback = callback
+            self.solve_started.set()
+            # Simulates CP-SAT spending a long time searching before the next
+            # solution callback. A responsive wrapper should interrupt this via
+            # StopSearch() after should_stop() becomes true.
+            self.stop_search_called.wait(timeout=0.5)
+            return cp_model.UNKNOWN
+
+        def StopSearch(self):
+            self.stop_search_called.set()
+
+    dummy_solver = BlockingCpSolver()
+    solver.solver = dummy_solver
+    stop_requested = threading.Event()
+    result = {}
+
+    def run_solve():
+        result["status"] = solver.solve(should_stop=stop_requested.is_set)
+
+    solve_thread = threading.Thread(target=run_solve)
+    solve_thread.start()
+    assert dummy_solver.solve_started.wait(timeout=1)
+
+    stop_requested.set()
+    solve_thread.join(timeout=1)
+
+    assert not solve_thread.is_alive()
+    assert isinstance(dummy_solver.callback, cp_model.CpSolverSolutionCallback)
+    assert dummy_solver.stop_search_called.is_set()
+    assert result["status"] == SolverStatus.UNKNOWN


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimization jobs can now be interrupted reliably while the solver is actively searching, quickly stopping the run and using the best feasible solution found so far.

* **Tests**
  * Added solver-level tests to confirm stop requests interrupt searches between solution callbacks.
  * Added an API endpoint test to verify a “finish now” request triggers solver stop behavior and returns the expected results/status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->