### PR TITLE
fix(web-frontend): Set shift type requirements default to empty instead of 1

### DIFF
--- a/core/tests/test_export_formatting.py
+++ b/core/tests/test_export_formatting.py
@@ -481,6 +481,40 @@ export:
         schedule(yaml_content, prettify=True)
 
 
+def test_export_extra_column_rejects_overlapping_explicit_coefficient_one():
+    yaml_content = b"""
+apiVersion: alpha
+dates:
+  range:
+    startDate: 2025-01-01
+    endDate: 2025-01-01
+people:
+  items:
+    - id: n1
+shiftTypes:
+  items:
+    - id: D
+    - id: A
+  groups:
+    - id: WORK
+      members: [D, A]
+preferences:
+  - type: at most one shift per day
+export:
+  extraColumns:
+    - type: count
+      header: Invalid overlap
+      countDates: [ALL]
+      countShiftTypes: [D, WORK]
+      countShiftTypeCoefficients:
+        - [D, 1]
+        - [WORK, 2]
+"""
+
+    with pytest.raises(ValueError, match="Duplicate export extra column coefficient"):
+        schedule(yaml_content, prettify=True)
+
+
 def test_export_xlsx_handles_unequal_trimmed_history_columns():
     yaml_content = b"""
 apiVersion: alpha

--- a/core/tests/test_preference_validation.py
+++ b/core/tests/test_preference_validation.py
@@ -361,6 +361,40 @@ preferences:
         scheduler.schedule(duplicate_coefficient_yaml)
 
 
+def test_shift_count_rejects_overlapping_explicit_coefficient_one():
+    yaml_content = b"""
+apiVersion: alpha
+dates:
+  range:
+    startDate: 2025-01-01
+    endDate: 2025-01-01
+people:
+  items:
+    - id: n1
+shiftTypes:
+  items:
+    - id: D
+    - id: A
+  groups:
+    - id: G
+      members: [D, A]
+preferences:
+  - type: at most one shift per day
+  - type: shift count
+    person: n1
+    countDates: ALL
+    countShiftTypes: [D, G]
+    countShiftTypeCoefficients:
+      - [D, 1]
+      - [G, 2]
+    expression: x = T
+    target: 1
+    weight: .inf
+"""
+    with pytest.raises(ValueError, match="Duplicate shift count coefficient"):
+        scheduler.schedule(yaml_content)
+
+
 def test_shift_type_successions_rejects_history_all_and_group_ids():
     history_all_yaml = b"""
 apiVersion: alpha
@@ -753,6 +787,36 @@ preferences:
     requiredNumPeople: 1
 """
     with pytest.raises(ValueError, match="Duplicate shift type requirement coefficient for 'D'"):
+        scheduler.schedule(yaml_content)
+
+
+def test_shift_type_requirements_rejects_overlapping_explicit_coefficient_one():
+    yaml_content = b"""
+apiVersion: alpha
+dates:
+  range:
+    startDate: 2025-01-01
+    endDate: 2025-01-01
+people:
+  items:
+    - id: n1
+shiftTypes:
+  items:
+    - id: D
+    - id: E
+  groups:
+    - id: Work
+      members: [D, E]
+preferences:
+  - type: at most one shift per day
+  - type: shift type requirement
+    shiftType: [[Work, D]]
+    shiftTypeCoefficients:
+      - [D, 1]
+      - [Work, 2]
+    requiredNumPeople: 1
+"""
+    with pytest.raises(ValueError, match="Duplicate shift type requirement coefficient for 'Work'"):
         scheduler.schedule(yaml_content)
 
 

--- a/web-frontend/e2e/export-extra-column-coefficients.spec.ts
+++ b/web-frontend/e2e/export-extra-column-coefficients.spec.ts
@@ -59,6 +59,6 @@ test('extra column coefficients persist through Save and Load YAML and page navi
     'xpath=ancestor::div[contains(@class, "px-4 py-2")][1]'
   );
   await extraColumnCard.getByRole('button', { name: 'Edit' }).click();
-  await expect(page.getByRole('spinbutton', { name: 'D' })).toHaveValue('1');
+  await expect(page.getByRole('spinbutton', { name: 'D' })).toHaveValue('');
   await expect(page.getByRole('spinbutton', { name: 'N' })).toHaveValue('3');
 });

--- a/web-frontend/src/app/export-layout/page.test.tsx
+++ b/web-frontend/src/app/export-layout/page.test.tsx
@@ -168,6 +168,19 @@ describe('ExportLayoutPage extra column coefficients', () => {
     expect(updateExportConfig).not.toHaveBeenCalled();
   });
 
+  it('blocks overlapping explicit coefficient one from an item and containing group', async () => {
+    const user = userEvent.setup();
+    renderExportLayoutPage();
+
+    await startExtraColumn(user, ['D', 'WORK']);
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'D' }), { target: { value: '1' } });
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'WORK' }), { target: { value: '2' } });
+    await user.click(screen.getByRole('button', { name: 'Add', exact: true }));
+
+    expect(screen.getByText('Shift type coefficients overlap: D, WORK include D')).toBeInTheDocument();
+    expect(updateExportConfig).not.toHaveBeenCalled();
+  });
+
   it('clears an overlap error when the count shift type selection changes', async () => {
     const user = userEvent.setup();
     renderExportLayoutPage();
@@ -311,12 +324,21 @@ describe('ExportLayoutPage extra column coefficients', () => {
 
   it('clears an invalid coefficient error after correction and saves the rule', async () => {
     const user = userEvent.setup();
-    renderExportLayoutPage();
+    renderExportLayoutPage({
+      formatting: [],
+      extraColumns: [{
+        type: 'count',
+        header: 'Score',
+        countShiftTypes: ['D', 'N'],
+        countShiftTypeCoefficients: [['D', 0]],
+        countDates: ['2026-01-01'],
+      }],
+      extraRows: [],
+    });
 
-    await startExtraColumn(user, ['D', 'N']);
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
     const coefficientInput = screen.getByRole('spinbutton', { name: 'D' });
-    await user.clear(coefficientInput);
-    await user.click(screen.getByRole('button', { name: 'Add', exact: true }));
+    await user.click(screen.getByRole('button', { name: 'Update', exact: true }));
 
     expect(screen.getByText('Coefficient for D must be an integer of at least 1')).toBeInTheDocument();
     expect(coefficientInput).toHaveClass('border-red-300');
@@ -326,7 +348,7 @@ describe('ExportLayoutPage extra column coefficients', () => {
     expect(screen.queryByText('Coefficient for D must be an integer of at least 1')).not.toBeInTheDocument();
     expect(coefficientInput).not.toHaveClass('border-red-300');
 
-    await user.click(screen.getByRole('button', { name: 'Add', exact: true }));
+    await user.click(screen.getByRole('button', { name: 'Update', exact: true }));
     expect(updateExportConfig).toHaveBeenCalledOnce();
     expect(updateExportConfig.mock.calls[0][0].extraColumns[0].countShiftTypeCoefficients).toEqual([['D', 2]]);
   });
@@ -393,12 +415,10 @@ describe('ExportLayoutPage extra column coefficients', () => {
     await user.type(screen.getByTitle('Enter right border color in hex'), 'red');
     await user.click(screen.getByRole('checkbox', { name: 'D' }));
     await user.click(screen.getByRole('checkbox', { name: 'N' }));
-    await user.clear(screen.getByRole('spinbutton', { name: 'D' }));
     await user.click(screen.getByRole('button', { name: 'Add', exact: true }));
 
     expect(screen.getByText('Column header is required')).toBeInTheDocument();
     expect(screen.getByText('Right Border Color must be a valid hex color in #RRGGBB format')).toBeInTheDocument();
-    expect(screen.getByText('Coefficient for D must be an integer of at least 1')).toBeInTheDocument();
     expect(screen.getByText('Select at least one date target to count over')).toBeInTheDocument();
     expect(updateExportConfig).not.toHaveBeenCalled();
   });
@@ -426,19 +446,20 @@ describe('ExportLayoutPage extra column coefficients', () => {
     expect(updateExportConfig).not.toHaveBeenCalled();
   });
 
-  it('clears an invalid coefficient error when the count shift type selection changes', async () => {
+  it('clears a coefficient error when the count shift type selection changes', async () => {
     const user = userEvent.setup();
     renderExportLayoutPage();
 
-    await startExtraColumn(user, ['D', 'N']);
-    await user.clear(screen.getByRole('spinbutton', { name: 'D' }));
+    await startExtraColumn(user, ['D', 'WORK']);
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'D' }), { target: { value: '2' } });
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'WORK' }), { target: { value: '3' } });
     await user.click(screen.getByRole('button', { name: 'Add', exact: true }));
 
-    expect(screen.getByText('Coefficient for D must be an integer of at least 1')).toBeInTheDocument();
+    expect(screen.getByText('Shift type coefficients overlap: D, WORK include D')).toBeInTheDocument();
 
     await user.click(screen.getByRole('checkbox', { name: 'D' }));
 
-    expect(screen.queryByText('Coefficient for D must be an integer of at least 1')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Shift type coefficients overlap/)).not.toBeInTheDocument();
   });
 
   it('preserves unrelated errors when a coefficient changes', async () => {

--- a/web-frontend/src/app/shift-counts/page.test.tsx
+++ b/web-frontend/src/app/shift-counts/page.test.tsx
@@ -139,6 +139,31 @@ describe('ShiftCountsPage', () => {
     expect(updatePreferencesByType.mock.calls[0][1][0].countShiftTypeCoefficients).toEqual([['WORK', 3]]);
   });
 
+  it('blocks overlapping selected shift types when coefficient one is explicit', async () => {
+    const user = userEvent.setup();
+    renderShiftCountsPage();
+
+    await fillRequiredFieldsAndSelectShiftTypes(user, ['D', 'WORK']);
+    setCoefficient('D', 1);
+    setCoefficient('WORK', 2);
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(screen.getByText('Shift type coefficients overlap: D, WORK include D')).toBeInTheDocument();
+    expect(updatePreferencesByType).not.toHaveBeenCalled();
+  });
+
+  it('saves explicit coefficient one', async () => {
+    const user = userEvent.setup();
+    renderShiftCountsPage();
+
+    await fillRequiredFieldsAndSelectShiftTypes(user, ['D']);
+    setCoefficient('D', 1);
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(updatePreferencesByType).toHaveBeenCalledOnce();
+    expect(updatePreferencesByType.mock.calls[0][1][0].countShiftTypeCoefficients).toEqual([['D', 1]]);
+  });
+
   it('allows non-overlapping non-default coefficients', async () => {
     const user = userEvent.setup();
     renderShiftCountsPage();
@@ -300,16 +325,47 @@ describe('ShiftCountsPage', () => {
   });
 
   it('shows all invalid coefficient errors and clears only the edited coefficient error', async () => {
+    mockUseSchedulingData.mockReturnValue({
+      dateData: {
+        range: {
+          startDate: new Date('2026-01-01T12:00:00.000Z'),
+          endDate: new Date('2026-01-01T12:00:00.000Z'),
+        },
+        items: [{ id: '2026-01-01', description: 'Jan 1' }],
+        groups: [],
+      },
+      peopleData: {
+        items: [{ id: 'P1', description: 'Person 1', history: [] }],
+        groups: [],
+      },
+      shiftTypeData: {
+        items: [
+          { id: 'D', description: 'Day' },
+          { id: 'N', description: 'Night' },
+        ],
+        groups: [],
+      },
+      getPreferencesByType: vi.fn(() => [{
+        type: 'shift count',
+        person: ['P1'],
+        countDates: ['2026-01-01'],
+        countShiftTypes: ['D', 'N'],
+        countShiftTypeCoefficients: [['D', 0], ['N', 0]],
+        expression: 'x >= T',
+        target: 0,
+        weight: -1,
+      }]),
+      updatePreferencesByType,
+      duplicatePreferenceByType,
+    });
     const user = userEvent.setup();
     renderShiftCountsPage();
 
-    await fillRequiredFieldsAndSelectShiftTypes(user, ['D', 'N']);
+    await user.click(screen.getByRole('button', { name: /edit/i }));
     const dayCoefficientInput = screen.getByRole('spinbutton', { name: 'D' });
     const nightCoefficientInput = screen.getByRole('spinbutton', { name: 'N' });
 
-    await user.clear(dayCoefficientInput);
-    await user.clear(nightCoefficientInput);
-    await user.click(screen.getByRole('button', { name: 'Add' }));
+    await user.click(screen.getByRole('button', { name: 'Update' }));
 
     expect(screen.getByText('Coefficient for D must be an integer of at least 1')).toBeInTheDocument();
     expect(screen.getByText('Coefficient for N must be an integer of at least 1')).toBeInTheDocument();
@@ -325,16 +381,47 @@ describe('ShiftCountsPage', () => {
   });
 
   it('clears multiple coefficient errors queued before a render', async () => {
+    mockUseSchedulingData.mockReturnValue({
+      dateData: {
+        range: {
+          startDate: new Date('2026-01-01T12:00:00.000Z'),
+          endDate: new Date('2026-01-01T12:00:00.000Z'),
+        },
+        items: [{ id: '2026-01-01', description: 'Jan 1' }],
+        groups: [],
+      },
+      peopleData: {
+        items: [{ id: 'P1', description: 'Person 1', history: [] }],
+        groups: [],
+      },
+      shiftTypeData: {
+        items: [
+          { id: 'D', description: 'Day' },
+          { id: 'N', description: 'Night' },
+        ],
+        groups: [],
+      },
+      getPreferencesByType: vi.fn(() => [{
+        type: 'shift count',
+        person: ['P1'],
+        countDates: ['2026-01-01'],
+        countShiftTypes: ['D', 'N'],
+        countShiftTypeCoefficients: [['D', 0], ['N', 0]],
+        expression: 'x >= T',
+        target: 0,
+        weight: -1,
+      }]),
+      updatePreferencesByType,
+      duplicatePreferenceByType,
+    });
     const user = userEvent.setup();
     renderShiftCountsPage();
 
-    await fillRequiredFieldsAndSelectShiftTypes(user, ['D', 'N']);
+    await user.click(screen.getByRole('button', { name: /edit/i }));
     const dayCoefficientInput = screen.getByRole('spinbutton', { name: 'D' });
     const nightCoefficientInput = screen.getByRole('spinbutton', { name: 'N' });
 
-    await user.clear(dayCoefficientInput);
-    await user.clear(nightCoefficientInput);
-    await user.click(screen.getByRole('button', { name: 'Add' }));
+    await user.click(screen.getByRole('button', { name: 'Update' }));
 
     expect(screen.getByText('Coefficient for D must be an integer of at least 1')).toBeInTheDocument();
     expect(screen.getByText('Coefficient for N must be an integer of at least 1')).toBeInTheDocument();

--- a/web-frontend/src/app/shift-type-requirements/page.test.tsx
+++ b/web-frontend/src/app/shift-type-requirements/page.test.tsx
@@ -152,6 +152,23 @@ describe('ShiftTypeRequirementsPage', () => {
     });
   });
 
+  it('blocks overlapping explicit coefficient one from a shift type and containing group', async () => {
+    const user = userEvent.setup();
+
+    renderShiftTypeRequirementsPage();
+
+    await user.click(screen.getByRole('button', { name: /add requirement/i }));
+    await user.click(screen.getByRole('radio', { name: 'Days' }));
+    await user.type(screen.getByRole('spinbutton', { name: 'D' }), '1');
+    await user.type(screen.getByRole('spinbutton', { name: 'Days' }), '2');
+    await user.click(screen.getByRole('checkbox', { name: 'P1' }));
+    await user.click(screen.getByRole('checkbox', { name: '01' }));
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(screen.getByText('Shift type coefficients overlap: D, Days include D')).toBeInTheDocument();
+    expect(updatePreferencesByType).not.toHaveBeenCalled();
+  });
+
   it('replaces the selected shift type when another radio option is selected', async () => {
     const user = userEvent.setup();
     mockUseSchedulingData.mockReturnValue({

--- a/web-frontend/src/components/CountShiftTypeCoefficientFields.test.tsx
+++ b/web-frontend/src/components/CountShiftTypeCoefficientFields.test.tsx
@@ -61,7 +61,7 @@ describe('CountShiftTypeCoefficientFields', () => {
     );
 
     expect(screen.getByText('Count Shift Type Coefficients')).toBeInTheDocument();
-    expect(screen.getByRole('spinbutton', { name: 'D' })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: 'D' })).toHaveValue(null);
   });
 
   it('shows coefficient inputs when more than one shift type is selected', () => {

--- a/web-frontend/src/utils/countShiftTypeCoefficients.test.ts
+++ b/web-frontend/src/utils/countShiftTypeCoefficients.test.ts
@@ -38,7 +38,7 @@ describe('countShiftTypeCoefficients', () => {
     const afterReselect = syncCoefficientPairs(['N', 'D'], afterDeselect, shiftTypeData);
 
     expect(afterDeselect).toEqual([['N', 2]]);
-    expect(afterReselect).toEqual([['D', 1], ['N', 2], ['WORK', 1]]);
+    expect(afterReselect).toEqual([['D', ''], ['N', 2], ['WORK', '']]);
   });
 
   it('uses selected item coverage to include fully covered groups', () => {
@@ -48,9 +48,17 @@ describe('countShiftTypeCoefficients', () => {
   it('expands selected groups into coefficient item options', () => {
     expect(syncCoefficientPairs(['WORK'], [['D', 2]], shiftTypeData)).toEqual([
       ['D', 2],
-      ['N', 1],
-      ['WORK', 1],
+      ['N', ''],
+      ['WORK', ''],
     ]);
+  });
+
+  it('leaves missing coefficients blank and omits them from output', () => {
+    expect(validateCoefficientPairs(['D', 'N'], [], shiftTypeData)).toEqual({
+      coefficients: [],
+      errorsById: {},
+      overlapError: undefined,
+    });
   });
 
   it('updates one coefficient while preserving selected pairs', () => {
@@ -69,9 +77,17 @@ describe('countShiftTypeCoefficients', () => {
     });
   });
 
-  it('omits defaults and detects overlap among non-default coefficients', () => {
+  it('detects overlap among explicit coefficients', () => {
     expect(validateCoefficientPairs(['D', 'WORK'], [['D', 2], ['WORK', 3]], shiftTypeData)).toEqual({
       coefficients: [['D', 2], ['WORK', 3]],
+      errorsById: {},
+      overlapError: 'Shift type coefficients overlap: D, WORK include D',
+    });
+  });
+
+  it('keeps explicit coefficient one and detects overlap against containing groups', () => {
+    expect(validateCoefficientPairs(['D', 'WORK'], [['D', 1], ['WORK', 2]], shiftTypeData)).toEqual({
+      coefficients: [['D', 1], ['WORK', 2]],
       errorsById: {},
       overlapError: 'Shift type coefficients overlap: D, WORK include D',
     });

--- a/web-frontend/src/utils/countShiftTypeCoefficients.ts
+++ b/web-frontend/src/utils/countShiftTypeCoefficients.ts
@@ -31,7 +31,7 @@ export function getCoefficientForShiftType(
   coefficients: DraftShiftCountTypeCoefficient[],
   shiftTypeId: string
 ): number | string {
-  return coefficients.find(([id]) => id === shiftTypeId)?.[1] ?? 1;
+  return coefficients.find(([id]) => id === shiftTypeId)?.[1] ?? '';
 }
 
 function getExpandedShiftTypeIdsById(shiftTypeData: { items: Item[]; groups: Group[] }): Map<string, readonly string[]> {
@@ -114,6 +114,10 @@ export function validateCoefficientPairs(
   const errorsById: Record<string, string> = {};
 
   for (const [shiftTypeId, coefficient] of syncedCoefficients) {
+    if (coefficient === '') {
+      continue;
+    }
+
     if (typeof coefficient !== 'number' || !Number.isInteger(coefficient) || coefficient < 1) {
       errorsById[shiftTypeId] = `Coefficient for ${shiftTypeId} must be an integer of at least 1`;
     }
@@ -124,7 +128,7 @@ export function validateCoefficientPairs(
   }
 
   const normalizedCoefficients = syncedCoefficients.filter(
-    ([, coefficient]) => coefficient !== 1
+    ([, coefficient]) => coefficient !== ''
   ) as ShiftCountTypeCoefficient[];
 
   return {


### PR DESCRIPTION
Original is confusing as 1 indicates empty. If Day=[D. D+], coefficients may be {Day: 2, D: 1}, where `D: 1` is ignored. Very non-intuitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unset coefficient fields now appear blank instead of defaulting to `1`.
  * Coefficient values of `1` are now preserved when explicitly entered.

* **Bug Fixes**
  * Improved validation to prevent saving when coefficient settings overlap between specific items and broader groups.
  * Fixed cases where overlapping coefficient setups could slip through in export, shift counts, and requirements.
  * Updated save/load behavior so cleared coefficient fields stay empty after navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->