### PR TITLE
Revamp optimize backend selector

### DIFF
--- a/web-frontend/e2e/optimize-and-export-http-server.spec.ts
+++ b/web-frontend/e2e/optimize-and-export-http-server.spec.ts
@@ -158,7 +158,10 @@ test('optimize and export works against a real local HTTP server instead of Play
     await expect(page.getByText('Schedule optimized and downloaded successfully!')).toHaveCount(0);
     await expect(page.getByText('Current YAML Preview')).toHaveCount(0);
 
-    await page.getByPlaceholder('http://localhost:8000').fill(`http://127.0.0.1:${port}`);
+    await page.getByText('Double-click to add URL').dblclick();
+    await page.getByPlaceholder('https://backend.example.test').fill(`http://127.0.0.1:${port}`);
+    await page.keyboard.press('Enter');
+
     await expect(page.getByRole('button', { name: 'Optimize and Download' })).toBeEnabled();
     await page.getByRole('button', { name: 'Optimize and Download' }).click();
 

--- a/web-frontend/src/app/optimize-and-export/page.test.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.test.tsx
@@ -119,8 +119,17 @@ const queueInitialLocalSelection = (fetchMock: ReturnType<typeof vi.fn>) => {
   return fetchMock;
 };
 
+async function editBackendEndpoint(user: ReturnType<typeof userEvent.setup>, from: string, to: string) {
+  await user.dblClick(await screen.findByTitle(from));
+  const endpointInput = screen.getByDisplayValue(from);
+  expect(endpointInput).toHaveAttribute('type', 'text');
+  await user.clear(endpointInput);
+  await user.type(endpointInput, to);
+  await user.tab();
+}
+
 describe('optimize backend server selection', () => {
-  it('prefers a healthy local backend over production when app versions are equally preferred', () => {
+  it('uses healthy backend list order without comparing app versions', () => {
     const selected = selectPreferredServer([
       {
         endpoint: PRODUCTION_API_URL,
@@ -129,7 +138,7 @@ describe('optimize backend server selection', () => {
           status: 'ok',
           version: 'alpha',
           apiVersion: 'alpha',
-          appVersion: 'frontend-test',
+          appVersion: 'newer-backend',
         },
       },
       {
@@ -139,7 +148,7 @@ describe('optimize backend server selection', () => {
           status: 'ok',
           version: 'alpha',
           apiVersion: 'alpha',
-          appVersion: 'frontend-test',
+          appVersion: 'older-backend',
         },
       },
     ]);
@@ -178,6 +187,7 @@ describe('OptimizeAndExportPage error handling', () => {
     vi.stubGlobal('EventSource', undefined);
     vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    window.localStorage.removeItem('nurse-scheduling-optimize-server-options');
   });
 
   it('surfaces raw non-JSON error bodies from the backend', async () => {
@@ -253,6 +263,7 @@ describe('OptimizeAndExportPage error handling', () => {
 
     await expect(screen.findByText('Server: Online')).resolves.toBeInTheDocument();
     expect(screen.getByText(/API version: alpha · Frontend version: frontend-test · Backend version: v-test/)).toBeInTheDocument();
+    expect(screen.getByText(/Last checked: .* · \d+ ms/)).toBeInTheDocument();
   });
 
   it('allows an empty solver timeout while editing and clears its run error only after a value change', async () => {
@@ -348,7 +359,7 @@ describe('OptimizeAndExportPage error handling', () => {
 
     render(<OptimizeAndExportPage />);
 
-    await expect(screen.findByDisplayValue(LOCAL_API_URL)).resolves.toBeInTheDocument();
+    await expect(screen.findByTitle(LOCAL_API_URL)).resolves.toBeInTheDocument();
     await expect(screen.findByText('Server: Offline')).resolves.toBeInTheDocument();
 
     expect(fetch).toHaveBeenCalledWith(`${LOCAL_API_URL}/health`, expect.objectContaining({ method: 'GET' }));
@@ -360,7 +371,7 @@ describe('OptimizeAndExportPage error handling', () => {
 
     render(<OptimizeAndExportPage />);
 
-    await expect(screen.findByDisplayValue(LOCAL_API_URL)).resolves.toBeInTheDocument();
+    await expect(screen.findByTitle(LOCAL_API_URL)).resolves.toBeInTheDocument();
     await expect(screen.findByText('Server: Online')).resolves.toBeInTheDocument();
     expect(screen.getByText(/frontend and backend versions do not match/i)).toBeInTheDocument();
     expect(fetch).not.toHaveBeenCalledWith(`${PRODUCTION_API_URL}/health`, expect.anything());
@@ -372,16 +383,100 @@ describe('OptimizeAndExportPage error handling', () => {
 
     render(<OptimizeAndExportPage />);
 
-    const endpointInput = await screen.findByDisplayValue(LOCAL_API_URL);
-    expect(endpointInput).toHaveAttribute('list', 'backend-api-candidates');
+    await expect(screen.findByTitle(LOCAL_API_URL)).resolves.toBeInTheDocument();
     const candidateValues = Array.from(document.querySelectorAll('#backend-api-candidates option'))
       .map(option => option.getAttribute('value'));
     expect(candidateValues).toEqual([LOCAL_API_URL]);
 
-    await user.clear(endpointInput);
-    await user.type(endpointInput, 'https://backend.example.test');
+    await editBackendEndpoint(user, LOCAL_API_URL, 'https://backend.example.test');
 
-    expect(screen.getByDisplayValue('https://backend.example.test')).toBeInTheDocument();
+    expect(screen.getByTitle('https://backend.example.test')).toBeInTheDocument();
+  });
+
+  it('hydrates stored backend options before the initial health check', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(healthyResponse({ appVersion: 'stored-backend' }));
+    window.localStorage.setItem('nurse-scheduling-optimize-server-options', JSON.stringify({
+      servers: [{ endpoint: 'https://stored-backend.example.test' }],
+      selectedServerEndpoint: 'https://stored-backend.example.test',
+    }));
+
+    render(<OptimizeAndExportPage />);
+
+    await expect(screen.findByTitle('https://stored-backend.example.test')).resolves.toBeInTheDocument();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      'https://stored-backend.example.test/health',
+      expect.objectContaining({ method: 'GET' })
+    ));
+    expect(fetchMock).not.toHaveBeenCalledWith(`${LOCAL_API_URL}/health`, expect.anything());
+  });
+
+  it('selects a backend when clicking anywhere on its row', async () => {
+    const user = userEvent.setup();
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(healthyResponse());
+    window.localStorage.setItem('nurse-scheduling-optimize-server-options', JSON.stringify({
+      servers: [
+        { endpoint: 'https://first-backend.example.test' },
+        { endpoint: 'https://second-backend.example.test' },
+      ],
+      selectedServerEndpoint: 'https://first-backend.example.test',
+    }));
+
+    render(<OptimizeAndExportPage />);
+
+    const secondBackend = await screen.findByTitle('https://second-backend.example.test');
+    await user.click(secondBackend.closest('tr') as HTMLTableRowElement);
+
+    expect(screen.getByLabelText('Select https://second-backend.example.test')).toBeChecked();
+    expect(screen.getByText('Server: Online').nextElementSibling).toHaveTextContent('https://second-backend.example.test');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://second-backend.example.test/health',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('disables backend dragging while editing and allows the blur click to select another row', async () => {
+    const user = userEvent.setup();
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(healthyResponse());
+    window.localStorage.setItem('nurse-scheduling-optimize-server-options', JSON.stringify({
+      servers: [
+        { endpoint: 'https://first-backend.example.test' },
+        { endpoint: 'https://second-backend.example.test' },
+      ],
+      selectedServerEndpoint: 'https://first-backend.example.test',
+    }));
+
+    render(<OptimizeAndExportPage />);
+
+    await user.dblClick(await screen.findByTitle('https://first-backend.example.test'));
+    const endpointInput = screen.getByDisplayValue('https://first-backend.example.test');
+    const secondRow = (await screen.findByTitle('https://second-backend.example.test')).closest('tr') as HTMLTableRowElement;
+
+    expect(endpointInput).toHaveFocus();
+    expect(secondRow.getAttribute('draggable')).toBe('false');
+
+    await user.click(secondRow);
+
+    expect(screen.getByLabelText('Select https://first-backend.example.test')).not.toBeChecked();
+    expect(screen.getByLabelText('Select https://second-backend.example.test')).toBeChecked();
+  });
+
+  it('cancels an empty add-backend edit on blur without validation noise', async () => {
+    const user = userEvent.setup();
+    queueInitialLocalSelection(fetch as unknown as ReturnType<typeof vi.fn>);
+
+    render(<OptimizeAndExportPage />);
+
+    await user.dblClick(await screen.findByText('Double-click to add URL'));
+    const addInput = screen.getByPlaceholderText('https://backend.example.test');
+    expect(addInput).toHaveFocus();
+
+    await user.tab();
+
+    expect(screen.getByText('Double-click to add URL')).toBeInTheDocument();
+    expect(screen.queryByText('Backend URL is required.')).not.toBeInTheDocument();
   });
 
   it('checks a user-entered endpoint and marks it offline after the health timeout', async () => {
@@ -391,12 +486,6 @@ describe('OptimizeAndExportPage error handling', () => {
 
     render(<OptimizeAndExportPage />);
 
-    const endpointInput = await screen.findByDisplayValue(LOCAL_API_URL);
-    await user.clear(endpointInput);
-    await user.type(endpointInput, 'https://backend.example.test');
-
-    expect(screen.getByText('Server: Checking')).toBeInTheDocument();
-
     fetchMock.mockImplementationOnce((_url: string, init?: RequestInit) => {
       return new Promise((_resolve, reject) => {
         init?.signal?.addEventListener('abort', () => {
@@ -404,6 +493,9 @@ describe('OptimizeAndExportPage error handling', () => {
         });
       });
     });
+    await editBackendEndpoint(user, LOCAL_API_URL, 'https://backend.example.test');
+
+    expect(screen.getByText('Server: Checking')).toBeInTheDocument();
 
     await waitFor(() => expect(fetch).toHaveBeenCalledWith(
       'https://backend.example.test/health',
@@ -431,8 +523,8 @@ describe('OptimizeAndExportPage error handling', () => {
 
     expect(screen.getByText('Server: Checking')).toBeInTheDocument();
     expect(screen.getByText('Checking API endpoints...')).toBeInTheDocument();
-    expect(screen.getByDisplayValue(LOCAL_API_URL)).not.toBeDisabled();
-    expect(screen.getByRole('button', { name: /check backend/i })).toBeDisabled();
+    expect(screen.getByTitle(LOCAL_API_URL)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /check backend/i })).toBeEnabled();
   });
 
   it('does not overwrite a user-entered endpoint when background discovery finishes', async () => {
@@ -455,9 +547,7 @@ describe('OptimizeAndExportPage error handling', () => {
 
     render(<OptimizeAndExportPage />);
 
-    const endpointInput = screen.getByDisplayValue(LOCAL_API_URL);
-    await user.clear(endpointInput);
-    await user.type(endpointInput, 'https://backend.example.test');
+    await editBackendEndpoint(user, LOCAL_API_URL, 'https://backend.example.test');
 
     act(() => {
       resolveDiscovery(healthyResponse());
@@ -466,7 +556,7 @@ describe('OptimizeAndExportPage error handling', () => {
     await waitFor(() => {
       expect(screen.queryByText('Checking API endpoints...')).not.toBeInTheDocument();
     });
-    expect(screen.getByDisplayValue('https://backend.example.test')).toBeInTheDocument();
+    expect(screen.getByTitle('https://backend.example.test')).toBeInTheDocument();
   });
 
   it('ignores manual health check results for an endpoint that is no longer current', async () => {
@@ -496,19 +586,15 @@ describe('OptimizeAndExportPage error handling', () => {
     render(<OptimizeAndExportPage />);
     await screen.findByText('Server: Online');
 
-    const endpointInput = screen.getByDisplayValue(LOCAL_API_URL);
-    await user.clear(endpointInput);
-    await user.type(endpointInput, 'https://backend.example.test');
-    await user.click(screen.getByRole('button', { name: /check backend/i }));
-    await user.clear(endpointInput);
-    await user.type(endpointInput, 'https://next-backend.example.test');
+    await editBackendEndpoint(user, LOCAL_API_URL, 'https://backend.example.test');
+    await editBackendEndpoint(user, 'https://backend.example.test', 'https://next-backend.example.test');
 
     act(() => {
       resolveManualCheck(healthyResponse({ appVersion: 'custom-backend' }));
     });
 
     await waitFor(() => {
-      expect(screen.getByDisplayValue('https://next-backend.example.test')).toBeInTheDocument();
+      expect(screen.getByTitle('https://next-backend.example.test')).toBeInTheDocument();
     });
     expect(screen.getByText('Server: Checking')).toBeInTheDocument();
   });
@@ -957,14 +1043,14 @@ describe('OptimizeAndExportPage error handling', () => {
       .mockResolvedValue({ ok: true });
 
     render(<OptimizeAndExportPage />);
-    await expect(screen.findByDisplayValue(LOCAL_API_URL)).resolves.toBeInTheDocument();
+    await expect(screen.findByTitle(LOCAL_API_URL)).resolves.toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /optimize and download/i }));
     await waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
 
     expect(MockEventSource.instances[0].url).toBe(`${LOCAL_API_URL}/optimize/opt_active/events`);
 
-    const endpointInput = screen.getByDisplayValue(LOCAL_API_URL);
-    expect(endpointInput).toBeDisabled();
+    await user.dblClick(screen.getByTitle(LOCAL_API_URL));
+    expect(screen.queryByDisplayValue(LOCAL_API_URL)).not.toBeInTheDocument();
 
     const heartbeatCallback = setIntervalSpy.mock.calls.find(([, delay]) => delay === 10_000)?.[0];
     expect(heartbeatCallback).toBeDefined();

--- a/web-frontend/src/app/optimize-and-export/page.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.tsx
@@ -436,7 +436,7 @@ export default function OptimizeAndExportPage() {
   const [anonymizeScheduleData, setAnonymizeScheduleData] = useState(true);
   const [timeoutArg, setTimeoutArg] = useState<number | string>(300);
   const [timeoutError, setTimeoutError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isOptimizing, setIsOptimizing] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [scheduleScore, setScheduleScore] = useState<number | null>(null);
@@ -492,12 +492,12 @@ export default function OptimizeAndExportPage() {
   const isRequiredDataMissing = isDateDataMissing || isPeopleDataMissing || isShiftTypeDataMissing;
   const isJobActive = Boolean(
     currentJobId &&
-    isLoading &&
+    isOptimizing &&
     scheduleStatus &&
     !TERMINAL_JOB_STATUSES.has(scheduleStatus.toLowerCase())
   );
   const isCancelling = scheduleStatus === 'cancelling';
-  const isOptimizeDisabled = isLoading || isRequiredDataMissing || activeServerStatus !== 'online';
+  const isOptimizeDisabled = isOptimizing || isRequiredDataMissing || activeServerStatus !== 'online';
   const optimizeDisabledReason = isRequiredDataMissing
     ? 'Complete the missing schedule configuration before optimizing.'
     : activeServerStatus !== 'online'
@@ -800,7 +800,7 @@ export default function OptimizeAndExportPage() {
 
     const runEndpoint = resolvedOptimizeEndpoint;
     setLockedOptimizeEndpoint(runEndpoint);
-    setIsLoading(true);
+    setIsOptimizing(true);
     setTimeoutError(null);
     setErrorMessage(null);
     setSuccessMessage(null);
@@ -901,7 +901,7 @@ export default function OptimizeAndExportPage() {
           : 'An unexpected error occurred during optimization'
       );
     } finally {
-      setIsLoading(false);
+      setIsOptimizing(false);
       setLockedOptimizeEndpoint(null);
     }
   };
@@ -956,7 +956,15 @@ export default function OptimizeAndExportPage() {
     if (!normalizedEndpoint) {
       setServerEntries(currentServers => currentServers.map(server => (
         server.endpoint === currentEndpoint
-          ? { ...server, status: 'unchecked', error: 'Backend URL is required.', health: null, pingMs: null }
+          ? {
+              ...server,
+              status: 'unchecked',
+              health: null,
+              error: 'Backend URL is required.',
+              lastCheckedAt: null,
+              pingMs: null,
+              healthProbeId: 0,
+            }
           : server
       )));
       return;
@@ -964,7 +972,15 @@ export default function OptimizeAndExportPage() {
     if (isDuplicateServerEndpoint(normalizedEndpoint, currentEndpoint)) {
       setServerEntries(currentServers => currentServers.map(server => (
         server.endpoint === currentEndpoint
-          ? { ...server, error: 'Backend URL already exists.' }
+          ? {
+              ...server,
+              status: 'unchecked',
+              health: null,
+              error: 'Backend URL already exists.',
+              lastCheckedAt: null,
+              pingMs: null,
+              healthProbeId: 0,
+            }
           : server
       )));
       return;
@@ -1066,7 +1082,7 @@ export default function OptimizeAndExportPage() {
       <button
         type="button"
         onClick={() => checkAllServers()}
-        disabled={isLoading}
+        disabled={isOptimizing}
         className="inline-flex items-center justify-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
       >
         <FiRefreshCw className="h-4 w-4" />
@@ -1075,7 +1091,7 @@ export default function OptimizeAndExportPage() {
       <button
         type="button"
         onClick={resetServers}
-        disabled={isLoading}
+        disabled={isOptimizing}
         className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
       >
         Reset
@@ -1093,7 +1109,7 @@ export default function OptimizeAndExportPage() {
                 type="radio"
                 checked={selectedServerEndpoint === 'auto'}
                 onChange={() => selectServer('auto')}
-                disabled={isLoading}
+                disabled={isOptimizing}
                 className="sr-only"
               />
               <span className={`min-w-0 border-l-4 pl-2 ${selectedServerEndpoint === 'auto' ? 'border-blue-500' : 'border-transparent'}`}>
@@ -1113,7 +1129,7 @@ export default function OptimizeAndExportPage() {
               type="radio"
               checked={selectedServerEndpoint === server.endpoint}
               onChange={() => selectServer(server.endpoint)}
-              disabled={isLoading}
+              disabled={isOptimizing}
               className="sr-only"
               aria-label={`Select ${server.endpoint}`}
             />
@@ -1126,7 +1142,7 @@ export default function OptimizeAndExportPage() {
                   updateServerEndpoint(server.endpoint, value);
                 }}
                 onCancel={finishBackendEndpointEdit}
-                onDoubleClick={isLoading ? undefined : () => setEditingServerEndpoint(server.endpoint)}
+                onDoubleClick={isOptimizing ? undefined : () => setEditingServerEndpoint(server.endpoint)}
                 className="min-w-0 truncate text-sm font-medium text-gray-900"
                 editClassName="w-full border-gray-300 bg-white text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
               />
@@ -1183,7 +1199,7 @@ export default function OptimizeAndExportPage() {
                 event.stopPropagation();
                 startServerCheck(row.server);
               }}
-              disabled={isLoading}
+              disabled={isOptimizing}
               aria-label={`Check Backend ${row.server.endpoint}`}
               title="Check backend"
               className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
@@ -1196,7 +1212,7 @@ export default function OptimizeAndExportPage() {
                 event.stopPropagation();
                 removeServer(row.server.endpoint);
               }}
-              disabled={isLoading}
+              disabled={isOptimizing}
               aria-label={`Remove Backend ${row.server.endpoint}`}
               title="Remove backend"
               className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-red-200 bg-white text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
@@ -1218,7 +1234,7 @@ export default function OptimizeAndExportPage() {
           setAddingServer(false);
           setAddServerError(null);
         }}
-        onDoubleClick={isLoading ? undefined : () => setAddingServer(true)}
+        onDoubleClick={isOptimizing ? undefined : () => setAddingServer(true)}
         placeholder="https://backend.example.test"
         emptyText="Double-click to add URL"
         className="min-w-0 truncate text-sm font-medium"
@@ -1240,10 +1256,10 @@ export default function OptimizeAndExportPage() {
 
   const runStatus = scheduleStatus
     ? formatRunStatus(scheduleStatus, currentJob?.queuePosition)
-    : isLoading
+    : isOptimizing
       ? 'Starting'
       : 'Idle';
-  const runStatusClasses = isLoading
+  const runStatusClasses = isOptimizing
     ? 'bg-blue-50 text-blue-700 ring-blue-200'
     : errorMessage
       ? 'bg-red-50 text-red-700 ring-red-200'
@@ -1326,7 +1342,7 @@ export default function OptimizeAndExportPage() {
                 title="Backend"
                 columns={backendTableColumns}
                 data={backendRows}
-                onReorder={isLoading || isEditingBackendServer ? undefined : reorderBackendRows}
+                onReorder={isOptimizing || isEditingBackendServer ? undefined : reorderBackendRows}
                 getRowClassName={(row) => (
                   row.kind === 'auto'
                     ? `${selectedServerEndpoint === 'auto' ? 'bg-blue-50 ring-1 ring-inset ring-blue-200' : ''} non-draggable`
@@ -1334,7 +1350,7 @@ export default function OptimizeAndExportPage() {
                       ? 'bg-blue-50 ring-1 ring-inset ring-blue-200'
                       : ''
                 )}
-                onRowClick={isEditingBackendServer
+                onRowClick={isOptimizing || isEditingBackendServer
                   ? undefined
                   : (row) => {
                       if (row.kind === 'auto') {
@@ -1457,7 +1473,7 @@ export default function OptimizeAndExportPage() {
                     : 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500'
                 }`}
               >
-                {isLoading ? (
+                {isOptimizing ? (
                   <>
                     <FiLoader className="h-5 w-5 animate-spin" />
                     Optimizing...
@@ -1496,7 +1512,7 @@ export default function OptimizeAndExportPage() {
             <div className="flex flex-col gap-3 border-b border-gray-200 pb-4 sm:flex-row sm:items-start sm:justify-between">
               <div>
                 <p className="text-xs font-medium uppercase text-gray-500">
-                  {isLoading ? 'Live Incumbent Score' : scheduleScore !== null ? 'Final Score' : 'Score'}
+                  {isOptimizing ? 'Live Incumbent Score' : scheduleScore !== null ? 'Final Score' : 'Score'}
                 </p>
                 <p className="mt-1 text-4xl font-bold text-gray-900">
                   {scheduleScore !== null ? formatScore(scheduleScore) : 'No incumbent yet'}
@@ -1504,7 +1520,7 @@ export default function OptimizeAndExportPage() {
                 <p className="mt-1 text-xs text-gray-500">Higher scores are better.</p>
               </div>
               <span className={`inline-flex w-fit items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold ring-1 ${runStatusClasses}`}>
-                {isLoading ? <FiLoader className="h-4 w-4 animate-spin" /> : successMessage ? <FiCheckCircle className="h-4 w-4" /> : errorMessage ? <FiAlertCircle className="h-4 w-4" /> : <FiActivity className="h-4 w-4" />}
+                {isOptimizing ? <FiLoader className="h-4 w-4 animate-spin" /> : successMessage ? <FiCheckCircle className="h-4 w-4" /> : errorMessage ? <FiAlertCircle className="h-4 w-4" /> : <FiActivity className="h-4 w-4" />}
                 {runStatus}
               </span>
             </div>
@@ -1512,13 +1528,13 @@ export default function OptimizeAndExportPage() {
             <div className="text-sm text-gray-600">
               {!currentJobId ? (
                 <p>No optimization has been started.</p>
-              ) : isLoading && scheduleStatus === 'queued' ? (
+              ) : isOptimizing && scheduleStatus === 'queued' ? (
                 <p>
                   {currentJob?.queuePosition
                     ? `Waiting in optimization queue at position ${currentJob.queuePosition}.`
                     : 'Waiting in optimization queue.'}
                 </p>
-              ) : isLoading && !incumbentResult ? (
+              ) : isOptimizing && !incumbentResult ? (
                 <p>Waiting for first feasible solution...</p>
               ) : incumbentResult ? (
                 <p>
@@ -1601,7 +1617,7 @@ export default function OptimizeAndExportPage() {
         </section>
       </div>
 
-      <details open={isLoading || Boolean(errorMessage) || !successMessage} className="rounded-lg border border-gray-200 bg-white">
+      <details open={isOptimizing || Boolean(errorMessage) || !successMessage} className="rounded-lg border border-gray-200 bg-white">
         <summary className="flex cursor-pointer list-none items-center gap-2 border-b border-gray-200 px-5 py-4">
           <FiActivity className="h-4 w-4 text-gray-500" />
           <h2 className="text-base font-semibold text-gray-900">Optimization Events</h2>
@@ -1610,7 +1626,7 @@ export default function OptimizeAndExportPage() {
         <div ref={eventLogRef} data-testid="optimization-events-log" className="max-h-[28rem] overflow-auto bg-gray-50">
           {sseEvents.length === 0 ? (
             <div className="px-5 py-6 text-sm text-gray-500">
-              <p>{isLoading ? 'Waiting for optimization events...' : 'No optimization events yet.'}</p>
+              <p>{isOptimizing ? 'Waiting for optimization events...' : 'No optimization events yet.'}</p>
             </div>
           ) : (
             <ul className="space-y-0 p-5">

--- a/web-frontend/src/app/optimize-and-export/page.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.tsx
@@ -20,9 +20,11 @@
 // The Optimize and Export page for Tab "11. Optimize and Export"
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import Link from 'next/link';
-import { FiDownload, FiAlertCircle, FiCheckCircle, FiLoader, FiRefreshCw, FiWifi, FiWifiOff, FiActivity } from 'react-icons/fi';
+import { FiDownload, FiAlertCircle, FiCheckCircle, FiLoader, FiRefreshCw, FiWifi, FiWifiOff, FiActivity, FiTrash2 } from 'react-icons/fi';
+import { DataTable } from '@/components/DataTable';
+import { InlineEdit } from '@/components/InlineEdit';
 import OptimizationProgressChart, { OptimizationProgressPoint } from '@/components/OptimizationProgressChart';
 import NumberInput from '@/components/NumberInput';
 import { useSchedulingData } from '@/hooks/useSchedulingData';
@@ -32,15 +34,13 @@ import { generateYamlFromState } from '@/utils/yamlGenerator';
 import { GITHUB_PRIVACY_URL } from '@/constants/urls';
 import {
   BACKEND_API_CANDIDATES,
-  INITIAL_BACKEND_API_URL,
-  selectOfflineFallbackBackendApiUrl,
   selectPreferredServer,
-  type ServerHealthCheckResult,
   type ServerHealthResponse,
 } from '@/app/optimize-and-export/serverSelection';
 import { CURRENT_APP_VERSION, parseVersionParts } from '@/utils/version';
 
-type ServerHealthStatus = 'checking' | 'online' | 'offline';
+type ServerStatus = 'unchecked' | 'checking' | 'online' | 'offline';
+type ServerSelection = 'auto' | string;
 
 interface OptimizeJobResponse {
   jobId: string;
@@ -78,11 +78,131 @@ interface OptimizePhaseEvent {
   message?: string;
 }
 
+interface OptimizeServerEntry {
+  endpoint: string;
+  status: ServerStatus;
+  health: ServerHealthResponse | null;
+  error: string | null;
+  lastCheckedAt: Date | null;
+  pingMs: number | null;
+  healthProbeId: number;
+}
+
+type BackendTableRow =
+  | { kind: 'auto' }
+  | { kind: 'server'; server: OptimizeServerEntry };
+
+interface StoredOptimizeServerEntry {
+  endpoint: string;
+}
+
+interface StoredOptimizeServerOptions {
+  servers: StoredOptimizeServerEntry[];
+  selectedServerEndpoint: ServerSelection;
+}
+
 const TERMINAL_JOB_STATUSES = new Set(['optimal', 'feasible', 'infeasible', 'cancelled', 'failed']);
 const OPTIMIZE_CLIENT_HEARTBEAT_INTERVAL_MS = 10_000;
 const HEALTH_CHECK_TIMEOUT_MS = 3000;
 const INITIAL_HEALTH_CHECK_TIMEOUT_MS = 3000;
-const OFFLINE_FALLBACK_BACKEND_API_URL = selectOfflineFallbackBackendApiUrl(BACKEND_API_CANDIDATES);
+const SERVER_OPTIONS_STORAGE_KEY = 'nurse-scheduling-optimize-server-options';
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+function createServerEntry(
+  server: StoredOptimizeServerEntry,
+  status: ServerStatus = 'unchecked',
+): OptimizeServerEntry {
+  return {
+    ...server,
+    status,
+    health: null,
+    error: null,
+    lastCheckedAt: null,
+    pingMs: null,
+    healthProbeId: 0,
+  };
+}
+
+function createDefaultServerEntries(): OptimizeServerEntry[] {
+  return BACKEND_API_CANDIDATES.map((endpoint) => createServerEntry({
+    endpoint,
+  }));
+}
+
+function toStoredServerOptions(
+  servers: OptimizeServerEntry[],
+  selectedServerEndpoint: ServerSelection,
+): StoredOptimizeServerOptions {
+  return {
+    servers: servers.map(({ endpoint }) => ({ endpoint })),
+    selectedServerEndpoint,
+  };
+}
+
+function dedupeServerEntries(servers: StoredOptimizeServerEntry[]): OptimizeServerEntry[] {
+  const seenEndpoints = new Set<string>();
+
+  return servers.reduce<OptimizeServerEntry[]>((entries, server) => {
+    if (typeof server.endpoint !== 'string') {
+      return entries;
+    }
+
+    const endpoint = normalizeEndpoint(server.endpoint);
+    if (!endpoint || seenEndpoints.has(endpoint)) {
+      return entries;
+    }
+
+    seenEndpoints.add(endpoint);
+    entries.push(createServerEntry({
+      endpoint,
+    }));
+    return entries;
+  }, []);
+}
+
+function loadStoredServerOptions(): { servers: OptimizeServerEntry[]; selectedServerEndpoint: ServerSelection } {
+  if (typeof window === 'undefined') {
+    return { servers: createDefaultServerEntries(), selectedServerEndpoint: 'auto' };
+  }
+
+  const stored = window.localStorage.getItem(SERVER_OPTIONS_STORAGE_KEY);
+  if (stored === null) {
+    return { servers: createDefaultServerEntries(), selectedServerEndpoint: 'auto' };
+  }
+
+  try {
+    const parsed = JSON.parse(stored) as Partial<StoredOptimizeServerOptions>;
+    if (!Array.isArray(parsed.servers)) {
+      return { servers: createDefaultServerEntries(), selectedServerEndpoint: 'auto' };
+    }
+
+    const servers = dedupeServerEntries(parsed.servers);
+    const parsedSelection = typeof parsed.selectedServerEndpoint === 'string'
+      ? parsed.selectedServerEndpoint
+      : 'auto';
+    const selectedServerEndpoint = parsedSelection === 'auto' || servers.some(server => server.endpoint === parsedSelection)
+      ? parsedSelection
+      : 'auto';
+
+    return {
+      servers,
+      selectedServerEndpoint,
+    };
+  } catch {
+    return { servers: createDefaultServerEntries(), selectedServerEndpoint: 'auto' };
+  }
+}
+
+function persistServerOptions(servers: OptimizeServerEntry[], selectedServerEndpoint: ServerSelection): void {
+  window.localStorage.setItem(
+    SERVER_OPTIONS_STORAGE_KEY,
+    JSON.stringify(toStoredServerOptions(servers, selectedServerEndpoint)),
+  );
+}
+
+function deleteStoredServerOptions(): void {
+  window.localStorage.removeItem(SERVER_OPTIONS_STORAGE_KEY);
+}
 
 function isDirtyAppVersion(version: string): boolean {
   return parseVersionParts(version).dirty;
@@ -103,9 +223,15 @@ function buildApiUrl(endpoint: string, path: string): string {
   return `${normalizeEndpoint(endpoint)}${path.startsWith('/') ? path : `/${path}`}`;
 }
 
-async function fetchServerHealth(endpoint: string, timeoutMs = HEALTH_CHECK_TIMEOUT_MS): Promise<ServerHealthResponse | null> {
+async function fetchServerHealth(
+  endpoint: string,
+  timeoutMs = HEALTH_CHECK_TIMEOUT_MS,
+  signal?: AbortSignal,
+): Promise<ServerHealthResponse | null> {
   const controller = new AbortController();
   const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
+  const abortController = () => controller.abort();
+  signal?.addEventListener('abort', abortController);
 
   try {
     const response = await fetch(`${endpoint}/health`, {
@@ -124,6 +250,7 @@ async function fetchServerHealth(endpoint: string, timeoutMs = HEALTH_CHECK_TIME
     return null;
   } finally {
     window.clearTimeout(timeoutId);
+    signal?.removeEventListener('abort', abortController);
   }
 }
 
@@ -257,6 +384,32 @@ function getEventBadgeClasses(type: string): string {
   return 'bg-gray-100 text-gray-700 ring-gray-200';
 }
 
+function getServerStatusBadgeClasses(status: ServerStatus): string {
+  if (status === 'online') {
+    return 'bg-green-50 text-green-700 ring-green-200';
+  }
+  if (status === 'offline') {
+    return 'bg-red-50 text-red-700 ring-red-200';
+  }
+  if (status === 'checking') {
+    return 'bg-gray-50 text-gray-600 ring-gray-200';
+  }
+  return 'bg-gray-100 text-gray-600 ring-gray-200';
+}
+
+function formatServerStatus(status: ServerStatus): string {
+  if (status === 'checking') {
+    return 'Checking';
+  }
+  if (status === 'online') {
+    return 'Online';
+  }
+  if (status === 'offline') {
+    return 'Offline';
+  }
+  return 'Unchecked';
+}
+
 export default function OptimizeAndExportPage() {
   const {
     apiVersionData,
@@ -269,7 +422,16 @@ export default function OptimizeAndExportPage() {
     filterAutoGeneratedState
   } = useSchedulingData();
 
-  const [apiEndpoint, setApiEndpoint] = useState(INITIAL_BACKEND_API_URL);
+  const initialServerOptions = useRef({
+    servers: createDefaultServerEntries(),
+    selectedServerEndpoint: 'auto' as ServerSelection,
+  });
+  const [serverEntries, setServerEntries] = useState<OptimizeServerEntry[]>(initialServerOptions.current.servers);
+  const [selectedServerEndpoint, setSelectedServerEndpoint] = useState<ServerSelection>(initialServerOptions.current.selectedServerEndpoint);
+  const [editingServerEndpoint, setEditingServerEndpoint] = useState<string | null>(null);
+  const [addingServer, setAddingServer] = useState(false);
+  const [addServerError, setAddServerError] = useState<string | null>(null);
+  const [lockedOptimizeEndpoint, setLockedOptimizeEndpoint] = useState<string | null>(null);
   const [prettifyArg, setPrettifyArg] = useState(true);
   const [anonymizeScheduleData, setAnonymizeScheduleData] = useState(true);
   const [timeoutArg, setTimeoutArg] = useState<number | string>(300);
@@ -285,22 +447,45 @@ export default function OptimizeAndExportPage() {
   const [progressPoints, setProgressPoints] = useState<OptimizationProgressPoint[]>([]);
   const [savedDownload, setSavedDownload] = useState<{ url: string; filename: string } | null>(null);
   const [sseEvents, setSseEvents] = useState<SseEventLogEntry[]>([]);
-  const [serverHealthStatus, setServerHealthStatus] = useState<ServerHealthStatus>('checking');
-  const [lastHealthCheckedAt, setLastHealthCheckedAt] = useState<Date | null>(null);
-  const [serverHealth, setServerHealth] = useState<ServerHealthResponse | null>(null);
-  const [isInitialServerChecking, setIsInitialServerChecking] = useState(true);
   const eventLogRef = useRef<HTMLDivElement | null>(null);
   const savedDownloadUrlRef = useRef<string | null>(null);
   const shouldScrollEventLogToBottomRef = useRef(true);
-  // Async health checks must compare against the endpoint current at completion time.
-  const apiEndpointRef = useRef(INITIAL_BACKEND_API_URL);
-  // The initial endpoint probe already sets health state; skip the debounce pass triggered when it completes.
-  const skipNextDebouncedHealthCheckRef = useRef(true);
-  // Only the newest health check may update online/offline state.
-  const latestHealthCheckIdRef = useRef(0);
-  // Preserve user-entered endpoint text when background discovery finishes.
-  const endpointEditedDuringDiscoveryRef = useRef(false);
-  const hasVersionMismatch = Boolean(serverHealth && hasAppVersionMismatch(CURRENT_APP_VERSION, serverHealth.appVersion));
+  // pageMountId invalidates async work from earlier page visits; healthProbeId
+  // orders repeated probes for the same endpoint within the current visit.
+  const pageMountIdRef = useRef(0);
+  const latestHealthProbeIdRef = useRef(0);
+  const serverProbeControllersRef = useRef<Map<string, AbortController>>(new Map());
+  const selectedServer = selectedServerEndpoint === 'auto'
+    ? null
+    : serverEntries.find(server => server.endpoint === selectedServerEndpoint) ?? null;
+  const autoServer = selectPreferredServer(
+    serverEntries
+      .map((server, index) => ({ server, index }))
+      .filter((entry): entry is { server: OptimizeServerEntry; index: number } => Boolean(entry.server.health && entry.server.status === 'online'))
+      .map(({ server, index }) => ({
+        endpoint: server.endpoint,
+        index,
+        health: server.health as ServerHealthResponse,
+      }))
+  );
+  const resolvedServer = selectedServerEndpoint === 'auto'
+    ? serverEntries.find(server => server.endpoint === autoServer?.endpoint) ?? null
+    : selectedServer;
+  const resolvedOptimizeEndpoint = lockedOptimizeEndpoint ?? resolvedServer?.endpoint ?? serverEntries[0]?.endpoint ?? '';
+  const autoServerStatus: ServerStatus = autoServer
+    ? 'online'
+    : serverEntries.some(server => server.status === 'checking')
+      ? 'checking'
+      : serverEntries.some(server => server.status === 'offline')
+        ? 'offline'
+        : 'unchecked';
+  const activeServerStatus: ServerStatus = selectedServerEndpoint === 'auto'
+    ? autoServerStatus
+    : selectedServer?.status ?? 'unchecked';
+  const activeServerHealth = selectedServerEndpoint === 'auto'
+    ? resolvedServer?.health ?? serverEntries.find(server => server.status === 'checking' && server.health)?.health ?? null
+    : selectedServer?.health ?? null;
+  const hasVersionMismatch = Boolean(activeServerHealth && hasAppVersionMismatch(CURRENT_APP_VERSION, activeServerHealth.appVersion));
   const isDateDataMissing = !dateData.range?.startDate || !dateData.range?.endDate || dateData.items.length === 0;
   const isPeopleDataMissing = peopleData.items.length === 0;
   const isShiftTypeDataMissing = shiftTypeData.items.length === 0 && shiftTypeData.groups.length === 0;
@@ -312,11 +497,11 @@ export default function OptimizeAndExportPage() {
     !TERMINAL_JOB_STATUSES.has(scheduleStatus.toLowerCase())
   );
   const isCancelling = scheduleStatus === 'cancelling';
-  const isOptimizeDisabled = isLoading || isRequiredDataMissing || serverHealthStatus === 'offline';
+  const isOptimizeDisabled = isLoading || isRequiredDataMissing || activeServerStatus !== 'online';
   const optimizeDisabledReason = isRequiredDataMissing
     ? 'Complete the missing schedule configuration before optimizing.'
-    : serverHealthStatus === 'offline'
-      ? 'Backend unavailable. Check the endpoint or start the backend.'
+    : activeServerStatus !== 'online'
+      ? 'Backend unavailable. Check or select an online backend.'
       : null;
 
   // Create the current state object for YAML export (filtering out autogenerated items)
@@ -372,110 +557,93 @@ export default function OptimizeAndExportPage() {
     }
   }, [sseEvents.length]);
 
-  const runHealthCheck = useCallback(async (endpoint: string) => {
-    const normalizedEndpoint = normalizeEndpoint(endpoint);
-    const healthCheckId = latestHealthCheckIdRef.current + 1;
-    latestHealthCheckIdRef.current = healthCheckId;
-
-    setServerHealthStatus('checking');
-
-    const health = normalizedEndpoint ? await fetchServerHealth(normalizedEndpoint) : null;
-    if (
-      latestHealthCheckIdRef.current !== healthCheckId ||
-      normalizeEndpoint(apiEndpointRef.current) !== normalizedEndpoint
-    ) {
-      return health;
-    }
-
-    setServerHealthStatus(health ? 'online' : 'offline');
-    setServerHealth(health);
-    setLastHealthCheckedAt(new Date());
-
-    return health;
+  useIsomorphicLayoutEffect(() => {
+    const storedServerOptions = loadStoredServerOptions();
+    initialServerOptions.current = storedServerOptions;
+    setServerEntries(storedServerOptions.servers);
+    setSelectedServerEndpoint(storedServerOptions.selectedServerEndpoint);
   }, []);
 
-  const selectInitialServer = useCallback(async () => {
-    const healthCheckId = latestHealthCheckIdRef.current + 1;
-    latestHealthCheckIdRef.current = healthCheckId;
+  const saveServerOptions = useCallback((servers: OptimizeServerEntry[], nextSelectedServerEndpoint = selectedServerEndpoint) => {
+    persistServerOptions(servers, nextSelectedServerEndpoint);
+  }, [selectedServerEndpoint]);
 
-    setIsInitialServerChecking(true);
-    setServerHealthStatus('checking');
-    setServerHealth(null);
+  const startServerCheck = useCallback((server: OptimizeServerEntry) => {
+    const endpoint = normalizeEndpoint(server.endpoint);
+    if (!endpoint) {
+      return;
+    }
 
-    const healthChecks = BACKEND_API_CANDIDATES.map(async (endpoint, index) => {
-      const health = await fetchServerHealth(endpoint, INITIAL_HEALTH_CHECK_TIMEOUT_MS);
-      return { endpoint, index, health };
+    const pageMountId = pageMountIdRef.current;
+    const healthProbeId = latestHealthProbeIdRef.current + 1;
+    latestHealthProbeIdRef.current = healthProbeId;
+    const startedAt = performance.now();
+
+    serverProbeControllersRef.current.get(endpoint)?.abort();
+    const controller = new AbortController();
+    serverProbeControllersRef.current.set(endpoint, controller);
+
+    setServerEntries(currentServers => currentServers.map(currentServer => (
+      currentServer.endpoint === endpoint
+        ? {
+            ...currentServer,
+            endpoint,
+            status: 'checking',
+            error: null,
+            healthProbeId,
+          }
+        : currentServer
+    )));
+
+    void fetchServerHealth(endpoint, INITIAL_HEALTH_CHECK_TIMEOUT_MS, controller.signal).then(health => {
+      const pingMs = Math.round(performance.now() - startedAt);
+      setServerEntries(currentServers => currentServers.map(currentServer => {
+        if (
+          pageMountId !== pageMountIdRef.current ||
+          normalizeEndpoint(currentServer.endpoint) !== endpoint ||
+          currentServer.healthProbeId !== healthProbeId
+        ) {
+          return currentServer;
+        }
+
+        return {
+          ...currentServer,
+          status: health ? 'online' : 'offline',
+          health,
+          error: health ? null : 'Backend is not responding.',
+          lastCheckedAt: new Date(),
+          pingMs,
+        };
+      }));
+    }).finally(() => {
+      if (serverProbeControllersRef.current.get(endpoint) === controller) {
+        serverProbeControllersRef.current.delete(endpoint);
+      }
+    });
+  }, []);
+
+  const checkAllServers = useCallback((servers = serverEntries) => {
+    servers.forEach(server => {
+      startServerCheck(server);
+    });
+  }, [serverEntries, startServerCheck]);
+
+  useEffect(() => {
+    pageMountIdRef.current += 1;
+    const pageMountId = pageMountIdRef.current;
+    const serverProbeControllers = serverProbeControllersRef.current;
+    initialServerOptions.current.servers.forEach(server => {
+      startServerCheck(server);
     });
 
-    const results = await Promise.all(healthChecks);
-    const selected = selectPreferredServer(
-      results.filter((result): result is ServerHealthCheckResult => Boolean(result.health))
-    );
-
-    if (latestHealthCheckIdRef.current !== healthCheckId) {
-      setIsInitialServerChecking(false);
-      return selected?.health ?? null;
-    }
-
-    if (endpointEditedDuringDiscoveryRef.current) {
-      skipNextDebouncedHealthCheckRef.current = false;
-      setIsInitialServerChecking(false);
-      return selected?.health ?? null;
-    }
-
-    if (selected) {
-      apiEndpointRef.current = selected.endpoint;
-      setApiEndpoint(selected.endpoint);
-      setServerHealthStatus('online');
-      setServerHealth(selected.health);
-    } else {
-      apiEndpointRef.current = OFFLINE_FALLBACK_BACKEND_API_URL;
-      setApiEndpoint(OFFLINE_FALLBACK_BACKEND_API_URL);
-      setServerHealthStatus('offline');
-      setServerHealth(null);
-    }
-    setLastHealthCheckedAt(new Date());
-    skipNextDebouncedHealthCheckRef.current = true;
-    setIsInitialServerChecking(false);
-    return selected?.health ?? null;
-  }, []);
-
-  useEffect(() => {
-    void selectInitialServer();
-  }, [selectInitialServer]);
-
-  useEffect(() => {
-    if (isInitialServerChecking) {
-      return;
-    }
-
-    const intervalId = window.setInterval(() => {
-      void runHealthCheck(apiEndpoint);
-    }, 30000);
-
     return () => {
-      window.clearInterval(intervalId);
+      serverProbeControllers.forEach(controller => controller.abort());
+      serverProbeControllers.clear();
+      if (pageMountIdRef.current === pageMountId) {
+        pageMountIdRef.current += 1;
+      }
     };
-  }, [apiEndpoint, isInitialServerChecking, runHealthCheck]);
-
-  useEffect(() => {
-    if (isInitialServerChecking) {
-      return;
-    }
-    if (skipNextDebouncedHealthCheckRef.current) {
-      skipNextDebouncedHealthCheckRef.current = false;
-      return;
-    }
-    const endpoint = normalizeEndpoint(apiEndpoint);
-
-    const timeoutId = window.setTimeout(() => {
-      void runHealthCheck(endpoint);
-    }, 500);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [apiEndpoint, isInitialServerChecking, runHealthCheck]);
+  }, [startServerCheck]);
 
   useEffect(() => {
     if (!currentJobId || !isJobActive) {
@@ -484,7 +652,7 @@ export default function OptimizeAndExportPage() {
 
     const sendHeartbeat = () => {
       const heartbeatPath = currentJob?.links.heartbeat ?? `/optimize/${currentJobId}/heartbeat`;
-      void fetch(buildApiUrl(apiEndpoint, heartbeatPath), {
+      void fetch(buildApiUrl(resolvedOptimizeEndpoint, heartbeatPath), {
         method: 'POST',
         cache: 'no-store',
       }).catch(() => {
@@ -496,10 +664,10 @@ export default function OptimizeAndExportPage() {
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [apiEndpoint, currentJob?.links.heartbeat, currentJobId, isJobActive]);
+  }, [currentJob?.links.heartbeat, currentJobId, isJobActive, resolvedOptimizeEndpoint]);
 
   const getOptimizeJobStatus = useCallback(async (job: OptimizeJobResponse): Promise<OptimizeJobResponse> => {
-    const response = await fetch(buildApiUrl(apiEndpoint, job.links.status), {
+    const response = await fetch(buildApiUrl(resolvedOptimizeEndpoint, job.links.status), {
       method: 'GET',
       cache: 'no-store',
     });
@@ -509,7 +677,7 @@ export default function OptimizeAndExportPage() {
     }
 
     return await response.json() as OptimizeJobResponse;
-  }, [apiEndpoint]);
+  }, [resolvedOptimizeEndpoint]);
 
   const pollOptimizeJob = useCallback((job: OptimizeJobResponse): Promise<OptimizeJobResponse> => {
     return new Promise((resolve, reject) => {
@@ -541,7 +709,7 @@ export default function OptimizeAndExportPage() {
 
     if (typeof EventSource !== 'undefined') {
       return new Promise((resolve, reject) => {
-        const eventSource = new EventSource(buildApiUrl(apiEndpoint, job.links.events));
+        const eventSource = new EventSource(buildApiUrl(resolvedOptimizeEndpoint, job.links.events));
 
         eventSource.addEventListener('status', (event) => {
           const parsedData = parseSseEventData(event);
@@ -601,7 +769,7 @@ export default function OptimizeAndExportPage() {
     }
 
     return pollOptimizeJob(job);
-  }, [apiEndpoint, appendSseEvent, pollOptimizeJob]);
+  }, [appendSseEvent, pollOptimizeJob, resolvedOptimizeEndpoint]);
 
   const handleOptimizeAndDownload = async () => {
     if (isRequiredDataMissing) {
@@ -624,6 +792,14 @@ export default function OptimizeAndExportPage() {
       return;
     }
 
+    if (activeServerStatus !== 'online' || !resolvedOptimizeEndpoint) {
+      setErrorMessage('Select an online backend before optimizing.');
+      setSuccessMessage(null);
+      return;
+    }
+
+    const runEndpoint = resolvedOptimizeEndpoint;
+    setLockedOptimizeEndpoint(runEndpoint);
     setIsLoading(true);
     setTimeoutError(null);
     setErrorMessage(null);
@@ -656,7 +832,7 @@ export default function OptimizeAndExportPage() {
 
       formData.append('timeout', String(timeoutArg));
 
-      const createResponse = await fetch(`${normalizeEndpoint(apiEndpoint)}/optimize`, {
+      const createResponse = await fetch(`${normalizeEndpoint(runEndpoint)}/optimize`, {
         method: 'POST',
         body: formData,
       });
@@ -688,7 +864,7 @@ export default function OptimizeAndExportPage() {
         throw new Error(`No downloadable schedule is available. Job status: ${completedJob.status}`);
       }
 
-      const xlsxResponse = await fetch(buildApiUrl(apiEndpoint, completedJob.links.xlsx), {
+      const xlsxResponse = await fetch(buildApiUrl(runEndpoint, completedJob.links.xlsx), {
         method: 'GET',
       });
 
@@ -712,7 +888,7 @@ export default function OptimizeAndExportPage() {
       setSavedDownload({ url, filename });
       downloadFileFromUrl(url, filename);
 
-      void fetch(buildApiUrl(apiEndpoint, `/optimize/${completedJob.jobId}`), {
+      void fetch(buildApiUrl(runEndpoint, `/optimize/${completedJob.jobId}`), {
         method: 'DELETE',
       });
 
@@ -726,6 +902,7 @@ export default function OptimizeAndExportPage() {
       );
     } finally {
       setIsLoading(false);
+      setLockedOptimizeEndpoint(null);
     }
   };
 
@@ -735,7 +912,7 @@ export default function OptimizeAndExportPage() {
     }
 
     try {
-      const response = await fetch(buildApiUrl(apiEndpoint, `/optimize/${currentJobId}/${action}`), {
+      const response = await fetch(buildApiUrl(resolvedOptimizeEndpoint, `/optimize/${currentJobId}/${action}`), {
         method: 'POST',
       });
 
@@ -762,16 +939,304 @@ export default function OptimizeAndExportPage() {
     downloadFileFromUrl(savedDownload.url, savedDownload.filename);
   };
 
-  const serverStatusClasses = serverHealthStatus === 'online'
+  const selectServer = (serverEndpoint: ServerSelection) => {
+    setSelectedServerEndpoint(serverEndpoint);
+    saveServerOptions(serverEntries, serverEndpoint);
+  };
+
+  const isDuplicateServerEndpoint = (endpoint: string, currentEndpoint?: string) => {
+    return serverEntries.some(server => (
+      server.endpoint !== currentEndpoint &&
+      normalizeEndpoint(server.endpoint) === endpoint
+    ));
+  };
+
+  const updateServerEndpoint = (currentEndpoint: string, endpoint: string) => {
+    const normalizedEndpoint = normalizeEndpoint(endpoint);
+    if (!normalizedEndpoint) {
+      setServerEntries(currentServers => currentServers.map(server => (
+        server.endpoint === currentEndpoint
+          ? { ...server, status: 'unchecked', error: 'Backend URL is required.', health: null, pingMs: null }
+          : server
+      )));
+      return;
+    }
+    if (isDuplicateServerEndpoint(normalizedEndpoint, currentEndpoint)) {
+      setServerEntries(currentServers => currentServers.map(server => (
+        server.endpoint === currentEndpoint
+          ? { ...server, error: 'Backend URL already exists.' }
+          : server
+      )));
+      return;
+    }
+
+    serverProbeControllersRef.current.get(currentEndpoint)?.abort();
+    serverProbeControllersRef.current.delete(currentEndpoint);
+
+    const nextSelectedServerEndpoint = selectedServerEndpoint === currentEndpoint
+      ? normalizedEndpoint
+      : selectedServerEndpoint;
+    const nextServers = serverEntries.map(server => (
+      server.endpoint === currentEndpoint
+        ? {
+            ...server,
+            endpoint: normalizedEndpoint,
+            status: 'unchecked' as const,
+            health: null,
+            error: null,
+            lastCheckedAt: null,
+            pingMs: null,
+            healthProbeId: 0,
+          }
+        : server
+    ));
+    setServerEntries(nextServers);
+    setSelectedServerEndpoint(nextSelectedServerEndpoint);
+    saveServerOptions(nextServers, nextSelectedServerEndpoint);
+    const changedServer = nextServers.find(server => server.endpoint === normalizedEndpoint);
+    if (changedServer) {
+      startServerCheck(changedServer);
+    }
+  };
+
+  const addServer = (endpoint: string) => {
+    const normalizedEndpoint = normalizeEndpoint(endpoint);
+    if (!normalizedEndpoint) {
+      setAddingServer(false);
+      setAddServerError(null);
+      return;
+    }
+    if (isDuplicateServerEndpoint(normalizedEndpoint)) {
+      setAddServerError('Backend URL already exists.');
+      return;
+    }
+    const nextServer = createServerEntry({
+      endpoint: normalizedEndpoint,
+    });
+    const nextServers = [...serverEntries, nextServer];
+    setServerEntries(nextServers);
+    saveServerOptions(nextServers);
+    setAddServerError(null);
+    setAddingServer(false);
+    startServerCheck(nextServer);
+  };
+
+  const removeServer = (serverEndpoint: string) => {
+    const nextServers = serverEntries.filter(server => server.endpoint !== serverEndpoint);
+    const nextSelectedServerEndpoint = selectedServerEndpoint === serverEndpoint ? 'auto' : selectedServerEndpoint;
+    serverProbeControllersRef.current.get(serverEndpoint)?.abort();
+    serverProbeControllersRef.current.delete(serverEndpoint);
+    setServerEntries(nextServers);
+    setSelectedServerEndpoint(nextSelectedServerEndpoint);
+    saveServerOptions(nextServers, nextSelectedServerEndpoint);
+  };
+
+  const reorderBackendRows = (rows: BackendTableRow[]) => {
+    const nextServers = rows
+      .filter((row): row is { kind: 'server'; server: OptimizeServerEntry } => row.kind === 'server')
+      .map(row => row.server);
+    setServerEntries(nextServers);
+    saveServerOptions(nextServers);
+  };
+
+  const resetServers = () => {
+    serverProbeControllersRef.current.forEach(controller => controller.abort());
+    serverProbeControllersRef.current.clear();
+    deleteStoredServerOptions();
+    const nextServers = createDefaultServerEntries();
+    setServerEntries(nextServers);
+    setSelectedServerEndpoint('auto');
+    setAddingServer(false);
+    setAddServerError(null);
+    nextServers.forEach(server => {
+      startServerCheck(server);
+    });
+  };
+
+  const backendRows: BackendTableRow[] = [
+    { kind: 'auto' },
+    ...serverEntries.map(server => ({ kind: 'server' as const, server })),
+  ];
+  const isEditingBackendServer = Boolean(editingServerEndpoint || addingServer);
+  const finishBackendEndpointEdit = () => {
+    setEditingServerEndpoint(null);
+  };
+  const backendTableHeaderAction = (
+    <div className="flex flex-wrap gap-2">
+      <button
+        type="button"
+        onClick={() => checkAllServers()}
+        disabled={isLoading}
+        className="inline-flex items-center justify-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
+      >
+        <FiRefreshCw className="h-4 w-4" />
+        Check all
+      </button>
+      <button
+        type="button"
+        onClick={resetServers}
+        disabled={isLoading}
+        className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
+      >
+        Reset
+      </button>
+    </div>
+  );
+  const backendTableColumns = [
+    {
+      header: 'Server',
+      accessor: (row: BackendTableRow) => {
+        if (row.kind === 'auto') {
+          return (
+            <label className="flex min-w-0 cursor-pointer items-start">
+              <input
+                type="radio"
+                checked={selectedServerEndpoint === 'auto'}
+                onChange={() => selectServer('auto')}
+                disabled={isLoading}
+                className="sr-only"
+              />
+              <span className={`min-w-0 border-l-4 pl-2 ${selectedServerEndpoint === 'auto' ? 'border-blue-500' : 'border-transparent'}`}>
+                <span className="block text-sm font-medium text-gray-900">Auto</span>
+                <span className="mt-0.5 block truncate text-xs text-gray-500">
+                  {autoServer ? `Uses ${autoServer.endpoint}` : 'Uses the first online server by priority.'}
+                </span>
+              </span>
+            </label>
+          );
+        }
+
+        const { server } = row;
+        return (
+          <label className="flex min-w-0 cursor-pointer items-start">
+            <input
+              type="radio"
+              checked={selectedServerEndpoint === server.endpoint}
+              onChange={() => selectServer(server.endpoint)}
+              disabled={isLoading}
+              className="sr-only"
+              aria-label={`Select ${server.endpoint}`}
+            />
+            <span className={`min-w-0 flex-1 border-l-4 pl-2 ${selectedServerEndpoint === server.endpoint ? 'border-blue-500' : 'border-transparent'}`}>
+              <InlineEdit
+                value={server.endpoint}
+                isEditing={editingServerEndpoint === server.endpoint}
+                onSave={(value) => {
+                  finishBackendEndpointEdit();
+                  updateServerEndpoint(server.endpoint, value);
+                }}
+                onCancel={finishBackendEndpointEdit}
+                onDoubleClick={isLoading ? undefined : () => setEditingServerEndpoint(server.endpoint)}
+                className="min-w-0 truncate text-sm font-medium text-gray-900"
+                editClassName="w-full border-gray-300 bg-white text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+              <span className="mt-1 block truncate text-xs text-gray-500">
+                Last checked: {formatCheckedTime(server.lastCheckedAt)}
+                {server.pingMs !== null ? ` · ${server.pingMs} ms` : ''}
+                {server.error ? ` · ${server.error}` : ''}
+              </span>
+            </span>
+          </label>
+        );
+      },
+    },
+    {
+      header: 'Status',
+      align: 'center' as const,
+      accessor: (row: BackendTableRow) => {
+        const status = row.kind === 'auto' ? autoServerStatus : row.server.status;
+        const label = row.kind === 'auto'
+          ? `Auto status: ${formatServerStatus(status)}`
+          : `${row.server.endpoint} status: ${formatServerStatus(status)}`;
+        return (
+          <span
+            aria-label={label}
+            title={formatServerStatus(status)}
+            className={`inline-flex h-8 w-8 items-center justify-center rounded-md ring-1 ${getServerStatusBadgeClasses(status)}`}
+          >
+            {status === 'checking' ? (
+              <FiLoader className="h-4 w-4 animate-spin" />
+            ) : status === 'offline' ? (
+              <FiWifiOff className="h-4 w-4" />
+            ) : status === 'online' ? (
+              <FiWifi className="h-4 w-4" />
+            ) : (
+              <FiWifi className="h-4 w-4 opacity-60" />
+            )}
+          </span>
+        );
+      },
+    },
+    {
+      header: 'Actions',
+      align: 'center' as const,
+      accessor: (row: BackendTableRow) => {
+        if (row.kind === 'auto') {
+          return <span />;
+        }
+
+        return (
+          <div className="flex items-center justify-center gap-1">
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                startServerCheck(row.server);
+              }}
+              disabled={isLoading}
+              aria-label={`Check Backend ${row.server.endpoint}`}
+              title="Check backend"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
+            >
+              <FiRefreshCw className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                removeServer(row.server.endpoint);
+              }}
+              disabled={isLoading}
+              aria-label={`Remove Backend ${row.server.endpoint}`}
+              title="Remove backend"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-red-200 bg-white text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
+            >
+              <FiTrash2 className="h-4 w-4" />
+            </button>
+          </div>
+        );
+      },
+    },
+  ];
+  const backendTableFooter = (
+    <div className="border-t border-gray-200 py-2 pl-8 pr-4">
+      <InlineEdit
+        value=""
+        isEditing={addingServer}
+        onSave={(value) => addServer(value)}
+        onCancel={() => {
+          setAddingServer(false);
+          setAddServerError(null);
+        }}
+        onDoubleClick={isLoading ? undefined : () => setAddingServer(true)}
+        placeholder="https://backend.example.test"
+        emptyText="Double-click to add URL"
+        className="min-w-0 truncate text-sm font-medium"
+        editClassName="w-full max-w-xl border-gray-300 bg-white text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+        error={addServerError ?? undefined}
+      />
+      {addServerError && (
+        <p className="mt-1 text-xs text-red-600">{addServerError}</p>
+      )}
+    </div>
+  );
+
+  const serverStatusClasses = activeServerStatus === 'online'
     ? 'border-green-200 bg-green-50 text-green-700'
-    : serverHealthStatus === 'offline'
+    : activeServerStatus === 'offline'
       ? 'border-red-200 bg-red-50 text-red-700'
       : 'border-gray-200 bg-gray-50 text-gray-600';
-  const serverStatusLabel = serverHealthStatus === 'online'
-    ? 'Online'
-    : serverHealthStatus === 'offline'
-      ? 'Offline'
-      : 'Checking';
+  const serverStatusLabel = formatServerStatus(activeServerStatus);
 
   const runStatus = scheduleStatus
     ? formatRunStatus(scheduleStatus, currentJob?.queuePosition)
@@ -798,9 +1263,9 @@ export default function OptimizeAndExportPage() {
 
         <div className={`inline-flex items-center gap-2.5 rounded-md border px-3 py-2 ${serverStatusClasses}`}>
           <span className="shrink-0">
-            {serverHealthStatus === 'offline' ? (
+            {activeServerStatus === 'offline' ? (
               <FiWifiOff className="h-4 w-4" />
-            ) : serverHealthStatus === 'checking' ? (
+            ) : activeServerStatus === 'checking' ? (
               <FiLoader className="h-4 w-4 animate-spin" />
             ) : (
               <FiWifi className="h-4 w-4" />
@@ -810,7 +1275,9 @@ export default function OptimizeAndExportPage() {
             <span className="block text-sm font-medium">
               Server: {serverStatusLabel}
             </span>
-            <span className="mt-0.5 block text-xs opacity-75">Last checked: {formatCheckedTime(lastHealthCheckedAt)}</span>
+            <span className="mt-0.5 block max-w-72 truncate text-xs opacity-75">
+              {resolvedOptimizeEndpoint || 'No backend'}
+            </span>
           </span>
         </div>
       </div>
@@ -850,137 +1317,135 @@ export default function OptimizeAndExportPage() {
       <div className="mb-6 grid gap-6 xl:grid-cols-[minmax(0,0.95fr)_minmax(380px,1.05fr)]">
         <section className="rounded-lg border border-gray-200 bg-white">
           <div className="border-b border-gray-200 px-5 py-4">
-            <h2 className="text-base font-semibold text-gray-900">Configuration</h2>
-            <p className="mt-0.5 text-sm text-gray-600">Solver and connection settings.</p>
+            <h2 className="text-base font-semibold text-gray-900">Setup and Run</h2>
+            <p className="mt-0.5 text-sm text-gray-600">Choose a backend, set run options, then optimize.</p>
           </div>
           <div className="space-y-5 p-5">
-            <div className="grid gap-4 md:grid-cols-2">
-              <label className="flex min-h-20 cursor-pointer items-start gap-3 rounded-md border border-gray-200 bg-gray-50 p-3">
-                <input
-                  type="checkbox"
-                  checked={prettifyArg}
-                  onChange={(e) => setPrettifyArg(e.target.checked)}
-                  className="mt-1 h-4 w-4 rounded text-blue-600 focus:ring-blue-500"
-                />
-                <span>
-                  <span className="block text-sm font-medium text-gray-800">Prettify XLSX</span>
-                  <span className="mt-1 block text-xs text-gray-500">Apply formatting to the generated workbook.</span>
-                </span>
-              </label>
-
-              <label className="flex min-h-20 cursor-pointer items-start gap-3 rounded-md border border-gray-200 bg-gray-50 p-3">
-                <input
-                  type="checkbox"
-                  checked={anonymizeScheduleData}
-                  onChange={(e) => setAnonymizeScheduleData(e.target.checked)}
-                  className="mt-1 h-4 w-4 rounded text-blue-600 focus:ring-blue-500"
-                />
-                <span>
-                  <span className="block text-sm font-medium text-gray-800">Anonymize schedule data</span>
-                  <span className="mt-1 block text-xs text-gray-500">Anonymize people IDs and remove descriptions before sending to the backend.</span>
-                </span>
-              </label>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Solver Timeout
-                </label>
-                <div className="flex items-center gap-2">
-                  <NumberInput
-                    value={timeoutArg}
-                    onChange={(e) => {
-                      const value = e.target.value;
-                      setTimeoutError(null);
-                      setTimeoutArg(value === '' ? '' : (Number.isInteger(Number(value)) ? Number(value) : value));
-                    }}
-                    min="1"
-                    max="3600"
-                    className={`block w-full rounded-md border bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition-colors focus:outline-none focus:ring-2 ${
-                      timeoutError
-                        ? 'border-red-300 focus:border-red-500 focus:ring-red-200'
-                        : 'border-gray-300 focus:border-blue-500 focus:ring-blue-200'
-                    }`}
-                    placeholder="300"
-                  />
-                  <span className="text-sm text-gray-500">sec</span>
-                </div>
-                {timeoutError && (
-                  <p className="mt-2 text-sm text-red-600 flex items-center gap-1">
-                    <FiAlertCircle className="h-4 w-4" />
-                    {timeoutError}
-                  </p>
+            <div className="space-y-3">
+              <DataTable
+                title="Backend"
+                columns={backendTableColumns}
+                data={backendRows}
+                onReorder={isLoading || isEditingBackendServer ? undefined : reorderBackendRows}
+                getRowClassName={(row) => (
+                  row.kind === 'auto'
+                    ? `${selectedServerEndpoint === 'auto' ? 'bg-blue-50 ring-1 ring-inset ring-blue-200' : ''} non-draggable`
+                    : selectedServerEndpoint === row.server.endpoint
+                      ? 'bg-blue-50 ring-1 ring-inset ring-blue-200'
+                      : ''
                 )}
-              </div>
+                onRowClick={isEditingBackendServer
+                  ? undefined
+                  : (row) => {
+                      if (row.kind === 'auto') {
+                        selectServer('auto');
+                      } else {
+                        selectServer(row.server.endpoint);
+                      }
+                    }}
+                headerAction={backendTableHeaderAction}
+                footer={backendTableFooter}
+              />
+              <datalist id="backend-api-candidates">
+                {BACKEND_API_CANDIDATES.map(endpoint => (
+                  <option key={endpoint} value={endpoint} />
+                ))}
+              </datalist>
+              {serverEntries.some(server => server.status === 'checking') && (
+                <p className="text-xs text-gray-500">Checking API endpoints...</p>
+              )}
+
+              {(activeServerHealth || activeServerStatus === 'offline') && (
+                <div className="space-y-2">
+                  {activeServerHealth && (
+                    <div className="rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
+                      <p>
+                        API version: {activeServerHealth.apiVersion ?? activeServerHealth.version} · Frontend version: {CURRENT_APP_VERSION} · Backend version: {activeServerHealth.appVersion}
+                      </p>
+                      {hasVersionMismatch && (
+                        <p className="mt-1 font-medium text-amber-700">
+                          Frontend and backend versions do not match. If nothing breaks, you can continue.
+                        </p>
+                      )}
+                    </div>
+                  )}
+
+                  {activeServerStatus === 'offline' && (
+                    <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                      <div className="flex gap-2">
+                        <FiAlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                        <span>Backend is not responding at the configured endpoint.</span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
-            <details open className="rounded-md border border-gray-200 bg-gray-50">
-              <summary className="cursor-pointer px-3 py-2 text-sm font-medium text-gray-700">
-                Backend settings
-              </summary>
-              <div className="space-y-4 border-t border-gray-200 p-3">
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  API Endpoint
-                </label>
-                <div className="flex flex-col gap-2 sm:flex-row">
-                  <input
-                    list="backend-api-candidates"
-                    type="text"
-                    value={apiEndpoint}
-                    disabled={isLoading}
-                    onChange={(e) => {
-                      if (isInitialServerChecking) {
-                        endpointEditedDuringDiscoveryRef.current = true;
-                      }
-                      apiEndpointRef.current = e.target.value;
-                      setApiEndpoint(e.target.value);
-                      setServerHealthStatus('checking');
-                      setServerHealth(null);
-                    }}
-                    className="block min-w-0 flex-1 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition-colors disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-                    placeholder="http://localhost:8000"
-                  />
-                  <datalist id="backend-api-candidates">
-                    {BACKEND_API_CANDIDATES.map(endpoint => (
-                      <option key={endpoint} value={endpoint} />
-                    ))}
-                  </datalist>
-                  <button
-                    type="button"
-                    onClick={() => void runHealthCheck(apiEndpoint)}
-                    disabled={isLoading || isInitialServerChecking}
-                    className="inline-flex items-center justify-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                  >
-                    <FiRefreshCw className="h-4 w-4" />
-                    Check Backend
-                  </button>
-                </div>
-                {isInitialServerChecking && (
-                  <p className="text-xs text-gray-500">Checking API endpoints...</p>
-                )}
-
-                {serverHealth && (
-                  <div className="rounded-md border border-gray-200 bg-white px-3 py-2 text-xs text-gray-600">
-                    <p>
-                      API version: {serverHealth.apiVersion ?? serverHealth.version} · Frontend version: {CURRENT_APP_VERSION} · Backend version: {serverHealth.appVersion}
-                    </p>
-                    {hasVersionMismatch && (
-                      <p className="mt-1 font-medium text-amber-700">
-                        Frontend and backend versions do not match. If nothing breaks, you can continue.
-                      </p>
-                    )}
-                  </div>
-                )}
-
-                {serverHealthStatus === 'offline' && (
-                  <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-                    <div className="flex gap-2">
-                      <FiAlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                      <span>Backend is not responding at the configured endpoint.</span>
-                    </div>
-                  </div>
-                )}
+            <div className="space-y-3 border-t border-gray-200 pt-5">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900">Run options</h3>
               </div>
-            </details>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="flex min-h-20 cursor-pointer items-start gap-3 rounded-md border border-gray-200 bg-gray-50 p-3">
+                  <input
+                    type="checkbox"
+                    checked={prettifyArg}
+                    onChange={(e) => setPrettifyArg(e.target.checked)}
+                    className="mt-1 h-4 w-4 rounded text-blue-600 focus:ring-blue-500"
+                  />
+                  <span>
+                    <span className="block text-sm font-medium text-gray-800">Prettify XLSX</span>
+                    <span className="mt-1 block text-xs text-gray-500">Apply formatting to the generated workbook.</span>
+                  </span>
+                </label>
+
+                <label className="flex min-h-20 cursor-pointer items-start gap-3 rounded-md border border-gray-200 bg-gray-50 p-3">
+                  <input
+                    type="checkbox"
+                    checked={anonymizeScheduleData}
+                    onChange={(e) => setAnonymizeScheduleData(e.target.checked)}
+                    className="mt-1 h-4 w-4 rounded text-blue-600 focus:ring-blue-500"
+                  />
+                  <span>
+                    <span className="block text-sm font-medium text-gray-800">Anonymize schedule data</span>
+                    <span className="mt-1 block text-xs text-gray-500">Anonymize people IDs and remove descriptions before sending to the backend.</span>
+                  </span>
+                </label>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Solver Timeout
+                  </label>
+                  <div className="flex items-center gap-2">
+                    <NumberInput
+                      value={timeoutArg}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setTimeoutError(null);
+                        setTimeoutArg(value === '' ? '' : (Number.isInteger(Number(value)) ? Number(value) : value));
+                      }}
+                      min="1"
+                      max="3600"
+                      className={`block w-full rounded-md border bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition-colors focus:outline-none focus:ring-2 ${
+                        timeoutError
+                          ? 'border-red-300 focus:border-red-500 focus:ring-red-200'
+                          : 'border-gray-300 focus:border-blue-500 focus:ring-blue-200'
+                      }`}
+                      placeholder="300"
+                    />
+                    <span className="text-sm text-gray-500">sec</span>
+                  </div>
+                  {timeoutError && (
+                    <p className="mt-2 text-sm text-red-600 flex items-center gap-1">
+                      <FiAlertCircle className="h-4 w-4" />
+                      {timeoutError}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
 
             <div className="border-t border-gray-200 pt-5">
               <button

--- a/web-frontend/src/app/optimize-and-export/page.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.tsx
@@ -952,8 +952,16 @@ export default function OptimizeAndExportPage() {
   };
 
   const updateServerEndpoint = (currentEndpoint: string, endpoint: string) => {
+    const invalidateCurrentProbe = () => {
+      serverProbeControllersRef.current.get(currentEndpoint)?.abort();
+      serverProbeControllersRef.current.delete(currentEndpoint);
+      latestHealthProbeIdRef.current += 1;
+      return latestHealthProbeIdRef.current;
+    };
+
     const normalizedEndpoint = normalizeEndpoint(endpoint);
     if (!normalizedEndpoint) {
+      const healthProbeId = invalidateCurrentProbe();
       setServerEntries(currentServers => currentServers.map(server => (
         server.endpoint === currentEndpoint
           ? {
@@ -963,13 +971,14 @@ export default function OptimizeAndExportPage() {
               error: 'Backend URL is required.',
               lastCheckedAt: null,
               pingMs: null,
-              healthProbeId: 0,
+              healthProbeId,
             }
           : server
       )));
       return;
     }
     if (isDuplicateServerEndpoint(normalizedEndpoint, currentEndpoint)) {
+      const healthProbeId = invalidateCurrentProbe();
       setServerEntries(currentServers => currentServers.map(server => (
         server.endpoint === currentEndpoint
           ? {
@@ -979,15 +988,14 @@ export default function OptimizeAndExportPage() {
               error: 'Backend URL already exists.',
               lastCheckedAt: null,
               pingMs: null,
-              healthProbeId: 0,
+              healthProbeId,
             }
           : server
       )));
       return;
     }
 
-    serverProbeControllersRef.current.get(currentEndpoint)?.abort();
-    serverProbeControllersRef.current.delete(currentEndpoint);
+    invalidateCurrentProbe();
 
     const nextSelectedServerEndpoint = selectedServerEndpoint === currentEndpoint
       ? normalizedEndpoint

--- a/web-frontend/src/app/optimize-and-export/serverSelection.ts
+++ b/web-frontend/src/app/optimize-and-export/serverSelection.ts
@@ -17,8 +17,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { compareVersionsDescending, CURRENT_APP_VERSION } from '@/utils/version';
-
 export interface ServerHealthResponse {
   status: string;
   version: string;
@@ -48,19 +46,5 @@ export function selectOfflineFallbackBackendApiUrl(candidates: string[]): string
 }
 
 export function selectPreferredServer(results: ServerHealthCheckResult[]): ServerHealthCheckResult | undefined {
-  return [...results].sort((a, b) => {
-    const aVersionMatches = a.health.appVersion === CURRENT_APP_VERSION;
-    const bVersionMatches = b.health.appVersion === CURRENT_APP_VERSION;
-
-    if (aVersionMatches !== bVersionMatches) {
-      return aVersionMatches ? -1 : 1;
-    }
-
-    const versionComparison = compareVersionsDescending(a.health.appVersion, b.health.appVersion);
-    if (versionComparison !== null && versionComparison !== 0) {
-      return versionComparison;
-    }
-
-    return a.index - b.index;
-  })[0];
+  return [...results].sort((a, b) => a.index - b.index)[0];
 }

--- a/web-frontend/src/components/DataTable.test.tsx
+++ b/web-frontend/src/components/DataTable.test.tsx
@@ -106,6 +106,39 @@ describe('DataTable', () => {
     expect(row.getAttribute('draggable')).toBe('false');
   });
 
+  it('calls onRowClick when a row is clicked', () => {
+    const onRowClick = vi.fn();
+    const data: Row[] = [{ id: 'a', name: 'Alpha' }];
+
+    render(
+      <DataTable<Row>
+        title="Rows"
+        columns={columns}
+        data={data}
+        onRowClick={onRowClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Alpha').closest('tr') as HTMLTableRowElement);
+
+    expect(onRowClick).toHaveBeenCalledWith({ id: 'a', name: 'Alpha' }, 0);
+  });
+
+  it('renders footer content below the table', () => {
+    const data: Row[] = [{ id: 'a', name: 'Alpha' }];
+
+    render(
+      <DataTable<Row>
+        title="Rows"
+        columns={columns}
+        data={data}
+        footer={<div>Footer action</div>}
+      />,
+    );
+
+    expect(screen.getByText('Footer action')).toBeInTheDocument();
+  });
+
   it('keeps order unchanged when dropping onto the same row index', () => {
     const onReorder = vi.fn();
     const data: Row[] = [

--- a/web-frontend/src/components/DataTable.tsx
+++ b/web-frontend/src/components/DataTable.tsx
@@ -34,10 +34,12 @@ interface DataTableProps<T> {
   data: T[];
   onReorder?: (newData: T[]) => void;
   getRowClassName?: (item: T, index: number) => string;
+  onRowClick?: (item: T, index: number) => void;
   headerAction?: ReactNode;
+  footer?: ReactNode;
 }
 
-export function DataTable<T>({ title, columns, data, onReorder, getRowClassName, headerAction }: DataTableProps<T>) {
+export function DataTable<T>({ title, columns, data, onReorder, getRowClassName, onRowClick, headerAction, footer }: DataTableProps<T>) {
   const draggedRowIndexRef = useRef<number | null>(null);
   const [dragOverState, setDragOverState] = useState<{ rowIndex: number; insertAfter: boolean } | null>(null);
 
@@ -133,7 +135,8 @@ export function DataTable<T>({ title, columns, data, onReorder, getRowClassName,
                 onDragOver={isDraggable ? (e) => handleDragOver(e, rowIndex) : undefined}
                 onDragLeave={isDraggable ? handleDragLeave : undefined}
                 onDrop={isDraggable ? (e) => handleDrop(e, rowIndex) : undefined}
-                className={`${isDraggable ? 'cursor-move hover:bg-gray-50' : ''} ${
+                onClick={onRowClick ? () => onRowClick(item, rowIndex) : undefined}
+                className={`${onRowClick ? 'cursor-pointer' : isDraggable ? 'cursor-move' : ''} ${isDraggable || onRowClick ? 'hover:bg-gray-50' : ''} ${
                   dragOverState?.rowIndex === rowIndex
                     ? (dragOverState.insertAfter ? 'border-b-2 border-b-blue-500' : 'border-t-2 border-t-blue-500')
                     : ''
@@ -160,6 +163,7 @@ export function DataTable<T>({ title, columns, data, onReorder, getRowClassName,
             })}
           </tbody>
       </table>
+      {footer}
     </div>
   );
 }


### PR DESCRIPTION
Replace the optimize backend endpoint input with an ordered server list using DataTable. Servers are keyed by URL, persisted separately in localStorage, and hydrated before the initial health check.

`Auto` now selects the first online server by list order. Health checks use pageMountId and healthProbeId guards to ignore stale results across remounts and repeated probes. This also fixes the race conditions in previous code. Where the user switch page before the 3s timeout expire and immediately switch back, the status will be incorrectly updated once and then after 3s.

Add row selection, inline URL editing, add/remove/check actions, drag reorder, and focused tests for hydration, stale probes, row selection, editing, and DataTable footer behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing multiple backend servers, including selecting, adding, editing, removing, and reordering endpoints.
  * The backend table now supports clicking a row to select a server (including an automatic selection mode) and shows per-server status and last-checked information.
  * Tables can now display an optional footer area for extra actions or content.
* **Bug Fixes**
  * Improved health probing and selection so optimization controls and messaging remain consistent during active jobs.
  * Enhanced handling for empty/invalid endpoint edits and offline server states, with clearer resolved-backend display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->