### PR TITLE
feat(web): add solver selection to optimize page

### DIFF
--- a/web-frontend/src/app/optimize-and-export/page.test.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.test.tsx
@@ -624,6 +624,14 @@ describe('OptimizeAndExportPage error handling', () => {
       });
 
     render(<OptimizeAndExportPage />);
+    const solverSelect = screen.getByRole('combobox', { name: /solver/i });
+    const solverOptions = Array.from((solverSelect as HTMLSelectElement).options);
+    expect(solverSelect).toHaveValue('ortools/cp-sat');
+    expect(solverOptions.map(option => option.text)).toContain('OR-Tools / CP-SAT (CPU)');
+    expect(solverOptions.map(option => option.text)).toContain('PuLP / cuOpt (GPU)');
+    expect(solverOptions.map(option => option.value)).not.toContain('pulp/cbc');
+
+    await user.selectOptions(solverSelect, 'pulp/cuopt');
     await user.click(screen.getByRole('button', { name: /optimize and download/i }));
 
     await expect(screen.findByText('Schedule optimized and downloaded successfully!')).resolves.toBeInTheDocument();
@@ -632,6 +640,11 @@ describe('OptimizeAndExportPage error handling', () => {
     expect(screen.getByText('OPTIMAL')).toBeInTheDocument();
 
     expect(fetch).toHaveBeenCalledWith('http://localhost:8000/optimize', expect.objectContaining({ method: 'POST' }));
+    const optimizePostCall = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([url, options]) => url === 'http://localhost:8000/optimize' && options?.method === 'POST'
+    );
+    expect(optimizePostCall?.[1].body).toBeInstanceOf(FormData);
+    expect((optimizePostCall?.[1].body as FormData).get('solver')).toBe('pulp/cuopt');
     expect(fetch).toHaveBeenCalledWith(
       'http://localhost:8000/optimize/opt_test',
       expect.objectContaining({ method: 'GET' })

--- a/web-frontend/src/app/optimize-and-export/page.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.tsx
@@ -272,6 +272,7 @@ export default function OptimizeAndExportPage() {
   const [apiEndpoint, setApiEndpoint] = useState(INITIAL_BACKEND_API_URL);
   const [prettifyArg, setPrettifyArg] = useState(true);
   const [anonymizeScheduleData, setAnonymizeScheduleData] = useState(true);
+  const [solverArg, setSolverArg] = useState('ortools/cp-sat');
   const [timeoutArg, setTimeoutArg] = useState<number | string>(300);
   const [timeoutError, setTimeoutError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -655,6 +656,7 @@ export default function OptimizeAndExportPage() {
       }
 
       formData.append('timeout', String(timeoutArg));
+      formData.append('solver', solverArg);
 
       const createResponse = await fetch(`${normalizeEndpoint(apiEndpoint)}/optimize`, {
         method: 'POST',
@@ -880,6 +882,21 @@ export default function OptimizeAndExportPage() {
                   <span className="mt-1 block text-xs text-gray-500">Anonymize people IDs and remove descriptions before sending to the backend.</span>
                 </span>
               </label>
+
+              <div>
+                <label htmlFor="solver-select" className="block text-sm font-medium text-gray-700 mb-2">
+                  Solver
+                </label>
+                <select
+                  id="solver-select"
+                  value={solverArg}
+                  onChange={(e) => setSolverArg(e.target.value)}
+                  className="block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                >
+                  <option value="ortools/cp-sat">OR-Tools / CP-SAT (CPU)</option>
+                  <option value="pulp/cuopt">PuLP / cuOpt (GPU)</option>
+                </select>
+              </div>
 
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">


### PR DESCRIPTION
## Summary

Adds a frontend-only solver selector to the Optimize and Export page.

Users can now choose between:

- OR-Tools / CP-SAT (CPU) -> `ortools/cp-sat`
- PuLP / cuOpt (GPU) -> `pulp/cuopt`

The selected solver is submitted through the existing `/optimize` FormData request.

## Changes

- Added a Solver dropdown to the existing Configuration section.
- Preserved `ortools/cp-sat` as the default solver.
- Included `solver=<selected solver>` in the existing `/optimize` FormData.
- Kept the existing backend, SSE flow, XLSX download flow, timeout, prettify, and YAML behavior unchanged.
- Did not expose `pulp/cbc` in the UI.

## Tests

- `./node_modules/.bin/vitest related --reporter=dot --silent=passed-only --bail=1 --passWithNoTests src/app/optimize-and-export/page.tsx`
- `./node_modules/.bin/eslint .`

Note: ESLint may print an existing TypeScript version support warning, but lint completes successfully.

## Notes

`pulp/cuopt` requires backend runtime support for cuOpt/GPU. If the backend environment does not support it, the existing backend error message is shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a solver selection dropdown to the Optimize and Export page.
  * Users can now choose between CPU and GPU solver options before starting an optimization.
  * The selected solver is included in the optimization request.

* **Tests**
  * Updated coverage to verify the solver dropdown options, default selection, and submitted request data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->