### PR TITLE
feat: expose backend activity and worker capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ JOB_REDIS_KEY_PREFIX=nurse_scheduling:jobs:v0 \
 uvicorn nurse_scheduling.serve:app --workers 3 --host 0.0.0.0 --port 8000 --no-access-log
 ```
 
-Workers renew a 90-second execution lease while optimizing. Set
-`JOB_CLAIM_LEASE_SECONDS` to change how long the server waits before marking a
-job failed after its worker disappears.
+Workers renew a 90-second presence lease while idle and optimizing. Set
+`JOB_WORKER_LEASE_SECONDS` to change how long the server waits before marking a
+worker offline and failing its active job.
 
 or with X11 forwarding for running Playwright interactive mode in the container:
 
@@ -463,11 +463,11 @@ JOB_REDIS_KEY_PREFIX=nurse_scheduling:jobs:v0 \
 uvicorn nurse_scheduling.serve:app --workers 3 --no-access-log
 ```
 
-The optional `JOB_CLAIM_LEASE_SECONDS` setting defaults to 90 seconds. Keep it
-long enough to tolerate brief Redis interruptions; each active worker renews
-its lease every third of that interval.
+The optional `JOB_WORKER_LEASE_SECONDS` setting defaults to 90 seconds. Keep it
+long enough to tolerate brief Redis interruptions. Every worker renews its
+presence lease every third of that interval, including while idle.
 
-Replayable event history is capped at 1,000 events per job; set
+Replayable event history is capped at 1,000 events per job. Set
 `JOB_MAX_EVENTS_PER_JOB` to choose a different positive limit.
 
 Without Docker, install and start Redis with your operating system package manager.
@@ -521,6 +521,8 @@ SCAN 0 MATCH nurse_scheduling:jobs:v0:* COUNT 100
 ZRANGE nurse_scheduling:jobs:v0:jobs 0 -1 WITHSCORES
 ZRANGE nurse_scheduling:jobs:v0:queue 0 -1 WITHSCORES
 SMEMBERS nurse_scheduling:jobs:v0:pending
+ZRANGE nurse_scheduling:jobs:v0:workers:leases 0 -1 WITHSCORES
+HGETALL nurse_scheduling:jobs:v0:workers:active
 GET nurse_scheduling:jobs:v0:job:<job-id>
 GET nurse_scheduling:jobs:v0:job:<job-id>:input
 XRANGE nurse_scheduling:jobs:v0:job:<job-id>:events - + COUNT 20

--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ ZRANGE nurse_scheduling:jobs:v0:jobs 0 -1 WITHSCORES
 ZRANGE nurse_scheduling:jobs:v0:queue 0 -1 WITHSCORES
 SMEMBERS nurse_scheduling:jobs:v0:pending
 ZRANGE nurse_scheduling:jobs:v0:workers:leases 0 -1 WITHSCORES
+HGETALL nurse_scheduling:jobs:v0:workers:tokens
 HGETALL nurse_scheduling:jobs:v0:workers:active
 GET nurse_scheduling:jobs:v0:job:<job-id>
 GET nurse_scheduling:jobs:v0:job:<job-id>:input

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -34,6 +34,8 @@ test paths when a narrower suite is known to be sufficient.
   immediately.
 - Worker shutdown uses normal claim expiry recovery. Do not add a separate
   persisted shutdown failure unless immediate terminal state becomes required.
+- A worker that cannot persist an execution outcome must relinquish its lease.
+  Continue only after cleanup succeeds, otherwise stop the claim loop.
 
 ## Testing
 - Normal tests live under `tests/`.

--- a/core/nurse_scheduling/server/app.py
+++ b/core/nurse_scheduling/server/app.py
@@ -168,7 +168,7 @@ def create_app(
             max_retained=settings.max_retained_jobs,
         ),
         retention_seconds=settings.job_retention_seconds,
-        claim_lease_seconds=settings.claim_lease_seconds,
+        worker_lease_seconds=settings.worker_lease_seconds,
         runtime_identity=runtime_identity,
     )
     worker = JobWorker(
@@ -176,7 +176,7 @@ def create_app(
         runner,
         worker_id=instance_id,
         claim_poll_seconds=settings.claim_poll_seconds,
-        claim_lease_seconds=settings.claim_lease_seconds,
+        worker_lease_seconds=settings.worker_lease_seconds,
         timeout_grace_seconds=settings.timeout_grace_seconds,
         unexpected_error_formatter=_format_unexpected_error,
     )
@@ -293,7 +293,7 @@ def create_app(
                 error,
             )
             return "job_store_unavailable"
-        if start_background and not worker.is_alive():
+        if start_background and not worker.is_ready():
             return "job_worker_unavailable"
         return None
 
@@ -307,8 +307,29 @@ def create_app(
                 content={**info_payload("unavailable"), "reason": unavailable_reason},
                 headers={"Cache-Control": "no-store"},
             )
+        try:
+            activity = controller.get_activity()
+        except Exception as error:
+            server_logger.warning(
+                "[server:info] job activity unavailable backend=%s error=%s",
+                settings.job_backend,
+                error,
+            )
+            return JSONResponse(
+                status_code=503,
+                content={**info_payload("unavailable"), "reason": "job_store_unavailable"},
+                headers={"Cache-Control": "no-store"},
+            )
         return JSONResponse(
-            content=info_payload("ready"),
+            content={
+                **info_payload("ready"),
+                "jobs": {
+                    "running": activity.running_jobs,
+                    "queued": activity.queued_jobs,
+                    "cancelling": activity.cancelling_jobs,
+                },
+                "workers": {"online": activity.online_workers},
+            },
             headers={"Cache-Control": "no-store"},
         )
 

--- a/core/nurse_scheduling/server/config.py
+++ b/core/nurse_scheduling/server/config.py
@@ -76,10 +76,10 @@ class ServerSettings:
     """Maximum replayable events retained for each job."""
     claim_poll_seconds: float = 1.0
     """Worker delay between attempts to claim a queued job."""
-    claim_lease_seconds: float = 90.0
-    """Time a worker claim remains valid without renewal."""
+    worker_lease_seconds: float = 90.0
+    """Time a worker remains online without renewing its shared lease."""
     maintenance_interval_seconds: float = 30.0
-    """Delay between claim-expiry and retention maintenance passes."""
+    """Delay between worker-expiry and retention maintenance passes."""
     sse_keepalive_seconds: float = 10.0
     """Maximum SSE wait before emitting a keepalive comment."""
     max_yaml_bytes: int = 2 * 1024 * 1024
@@ -112,7 +112,7 @@ class ServerSettings:
                 raise ValueError(f"{name} must be positive")
         for name in (
             "claim_poll_seconds",
-            "claim_lease_seconds",
+            "worker_lease_seconds",
             "maintenance_interval_seconds",
             "sse_keepalive_seconds",
             "timeout_grace_seconds",
@@ -141,7 +141,7 @@ class ServerSettings:
             job_retention_seconds=_positive_int("JOB_RETENTION_SECONDS", DEFAULT_JOB_RETENTION_SECONDS),
             max_events_per_job=_positive_int("JOB_MAX_EVENTS_PER_JOB", DEFAULT_MAX_EVENTS_PER_JOB),
             claim_poll_seconds=_positive_float("JOB_CLAIM_POLL_SECONDS", 1.0),
-            claim_lease_seconds=_positive_float("JOB_CLAIM_LEASE_SECONDS", 90.0),
+            worker_lease_seconds=_positive_float("JOB_WORKER_LEASE_SECONDS", 90.0),
             maintenance_interval_seconds=_positive_float("JOB_MAINTENANCE_INTERVAL_SECONDS", 30.0),
             sse_keepalive_seconds=_positive_float("JOB_SSE_KEEPALIVE_SECONDS", 10.0),
             max_yaml_bytes=_positive_int("OPTIMIZE_MAX_YAML_BYTES", 2 * 1024 * 1024),

--- a/core/nurse_scheduling/server/job_store.py
+++ b/core/nurse_scheduling/server/job_store.py
@@ -21,7 +21,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from datetime import datetime
 from typing import Protocol
 
-from .jobs.models import Job, JobEvent, ServerActivity, StoredArtifact, StoreLimits
+from .jobs.models import Job, JobEvent, ServerActivity, StoredArtifact, StoreLimits, WorkerLease
 
 
 class JobStore(Protocol):
@@ -75,7 +75,7 @@ class JobStore(Protocol):
 
     def claim_next_job(
         self,
-        worker_id: str,
+        lease: WorkerLease,
         started_at: datetime,
         runtime_identity: Mapping[str, str] | None = None,
     ) -> Job | None:
@@ -86,20 +86,24 @@ class JobStore(Protocol):
         """
         ...
 
-    def register_worker(self, worker_id: str, registered_at: datetime, lease_expires_at: datetime) -> bool:
+    def register_worker(self, lease: WorkerLease, registered_at: datetime) -> bool:
         """Register an idle worker unless its unresolved prior lease prevents it."""
         ...
 
-    def renew_worker(self, worker_id: str, renewed_at: datetime, lease_expires_at: datetime) -> bool:
+    def renew_worker(self, lease: WorkerLease, renewed_at: datetime, lease_expires_at: datetime) -> bool:
         """Renew an unexpired worker lease without resurrecting an expired lease."""
         ...
 
-    def unregister_worker(self, worker_id: str) -> None:
-        """Remove a worker lease and its active-job association."""
+    def unregister_worker(self, lease: WorkerLease) -> None:
+        """Remove a matching worker lease and its active-job association."""
         ...
 
     def worker_owns_job(self, worker_id: str, job_id: str, observed_at: datetime) -> bool:
         """Return whether a live worker lease is associated with the job."""
+        ...
+
+    def lease_owns_job(self, lease: WorkerLease, job_id: str, observed_at: datetime) -> bool:
+        """Return whether this exact live lease is associated with the job."""
         ...
 
     def get_activity(self, observed_at: datetime) -> ServerActivity:
@@ -112,8 +116,15 @@ class JobStore(Protocol):
         expected_revision: int,
         events: Sequence[JobEvent],
         artifact: StoredArtifact | None = None,
+        *,
+        worker_lease: WorkerLease | None = None,
+        worker_lease_observed_at: datetime | None = None,
     ) -> Job:
-        """Update a job only if no concurrent update has occurred.
+        """Update a job if its revision and optional worker lease still match.
+
+        Omit `worker_lease` only for server-authorized API or maintenance
+        transitions. Worker-originated updates must include the lease and its
+        observation time.
 
         Raises:
             JobNotFoundError: If the job does not exist.

--- a/core/nurse_scheduling/server/job_store.py
+++ b/core/nurse_scheduling/server/job_store.py
@@ -98,7 +98,7 @@ class JobStore(Protocol):
         """Remove a matching worker lease and its active-job association."""
         ...
 
-    def worker_owns_job(self, worker_id: str, job_id: str, observed_at: datetime) -> bool:
+    def live_worker_owns_job(self, worker_id: str, job_id: str, observed_at: datetime) -> bool:
         """Return whether a live worker lease is associated with the job."""
         ...
 

--- a/core/nurse_scheduling/server/job_store.py
+++ b/core/nurse_scheduling/server/job_store.py
@@ -21,7 +21,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from datetime import datetime
 from typing import Protocol
 
-from .jobs.models import Job, JobEvent, StoredArtifact, StoreLimits
+from .jobs.models import Job, JobEvent, ServerActivity, StoredArtifact, StoreLimits
 
 
 class JobStore(Protocol):
@@ -73,11 +73,10 @@ class JobStore(Protocol):
         """
         ...
 
-    def claim_next(
+    def claim_next_job(
         self,
         worker_id: str,
         started_at: datetime,
-        claim_expires_at: datetime,
         runtime_identity: Mapping[str, str] | None = None,
     ) -> Job | None:
         """Atomically claim the next queued job for a worker.
@@ -87,14 +86,34 @@ class JobStore(Protocol):
         """
         ...
 
-    def save(
+    def register_worker(self, worker_id: str, registered_at: datetime, lease_expires_at: datetime) -> bool:
+        """Register an idle worker unless its unresolved prior lease prevents it."""
+        ...
+
+    def renew_worker(self, worker_id: str, renewed_at: datetime, lease_expires_at: datetime) -> bool:
+        """Renew an unexpired worker lease without resurrecting an expired lease."""
+        ...
+
+    def unregister_worker(self, worker_id: str) -> None:
+        """Remove a worker lease and its active-job association."""
+        ...
+
+    def worker_owns_job(self, worker_id: str, job_id: str, observed_at: datetime) -> bool:
+        """Return whether a live worker lease is associated with the job."""
+        ...
+
+    def get_activity(self, observed_at: datetime) -> ServerActivity:
+        """Return aggregate current job states and live workers."""
+        ...
+
+    def update_job(
         self,
         job: Job,
         expected_revision: int,
         events: Sequence[JobEvent],
         artifact: StoredArtifact | None = None,
     ) -> Job:
-        """Save a job update only if no concurrent update has occurred.
+        """Update a job only if no concurrent update has occurred.
 
         Raises:
             JobNotFoundError: If the job does not exist.
@@ -124,11 +143,15 @@ class JobStore(Protocol):
         """
         ...
 
-    def find_claimed_before(self, cutoff: datetime) -> list[Job]:
-        """Return active jobs whose worker claim expired by the cutoff.
+    def find_jobs_without_live_workers(self, observed_at: datetime) -> list[Job]:
+        """Return active jobs without a matching live worker lease.
 
         Maintenance terminates them because their worker is presumed lost.
         """
+        ...
+
+    def remove_expired_worker_leases(self, observed_at: datetime) -> list[str]:
+        """Remove expired worker leases and return their worker IDs."""
         ...
 
     def check_health(self) -> None:

--- a/core/nurse_scheduling/server/jobs/controller.py
+++ b/core/nurse_scheduling/server/jobs/controller.py
@@ -541,7 +541,8 @@ class JobController:
                 nonlocal did_expire
                 did_expire = False
                 if job.state not in {JobState.RUNNING, JobState.CANCELLING} or (
-                    job.worker_id is not None and self._store.worker_owns_job(job.worker_id, job.id, transition_time)
+                    job.worker_id is not None
+                    and self._store.live_worker_owns_job(job.worker_id, job.id, transition_time)
                 ):
                     return job, [], None
                 if job.cancel_requested:

--- a/core/nurse_scheduling/server/jobs/controller.py
+++ b/core/nurse_scheduling/server/jobs/controller.py
@@ -40,6 +40,7 @@ from .models import (
     JobRequest,
     JobState,
     OptimizationResult,
+    ServerActivity,
     StoredArtifact,
     StoreLimits,
 )
@@ -72,7 +73,7 @@ class JobController:
         *,
         limits: StoreLimits,
         retention_seconds: int,
-        claim_lease_seconds: float,
+        worker_lease_seconds: float,
         runtime_identity: Mapping[str, str] | None = None,
         clock: Clock = utc_now,
         id_factory: IdFactory = new_job_id,
@@ -84,8 +85,8 @@ class JobController:
         """Pending and retained capacity enforced during job creation."""
         self._retention_seconds = retention_seconds
         """Age after which terminal job history is eligible for deletion."""
-        self._claim_lease_seconds = claim_lease_seconds
-        """Duration assigned to each new or renewed worker claim."""
+        self._worker_lease_seconds = worker_lease_seconds
+        """Duration assigned to each new or renewed worker presence lease."""
         self._runtime_identity = runtime_identity
         """Identity recorded when this API process accepts or claims a job."""
         self._clock = clock
@@ -182,16 +183,45 @@ class JobController:
             raise JobArtifactNotReadyError("The schedule artifact is not ready")
         return self._store.get_artifact(job_id, name)
 
+    def register_worker(self, worker_id: str) -> datetime | None:
+        """Register an idle worker and return its lease expiration."""
+        now = self._clock()
+        lease_expires_at = now + timedelta(seconds=self._worker_lease_seconds)
+        registered = self._store.register_worker(
+            worker_id,
+            now,
+            lease_expires_at,
+        )
+        return lease_expires_at if registered else None
+
+    def renew_worker(self, worker_id: str) -> datetime | None:
+        """Renew a worker presence lease and return its new expiration."""
+        now = self._clock()
+        lease_expires_at = now + timedelta(seconds=self._worker_lease_seconds)
+        renewed = self._store.renew_worker(
+            worker_id,
+            now,
+            lease_expires_at,
+        )
+        return lease_expires_at if renewed else None
+
+    def unregister_worker(self, worker_id: str) -> None:
+        """Remove a worker presence lease and active-job association."""
+        self._store.unregister_worker(worker_id)
+
+    def get_activity(self) -> ServerActivity:
+        """Return current aggregate job and worker activity."""
+        return self._store.get_activity(self._clock())
+
     def claim_next_job(self, worker_id: str) -> Job | None:
-        """Claim the next queued job and assign it a worker lease.
+        """Claim the next queued job for a registered idle worker.
 
         Return the claimed running job, or `None` when the queue is empty.
         """
         now = self._clock()
-        job = self._store.claim_next(
+        job = self._store.claim_next_job(
             worker_id,
             now,
-            now + timedelta(seconds=self._claim_lease_seconds),
             self._runtime_identity,
         )
         if job is not None:
@@ -221,42 +251,14 @@ class JobController:
 
         def transition(job: Job, now: datetime) -> tuple[Job, list[JobEvent], StoredArtifact | None]:
             """Append an event only while the reporting worker owns an active job."""
-            if job.state.terminal or (worker_id is not None and job.worker_id != worker_id):
+            if job.state.terminal or (
+                worker_id is not None
+                and (job.worker_id != worker_id or not self._store.worker_owns_job(worker_id, job.id, now))
+            ):
                 return job, [], None
             return job, [JobEvent(type=event_type, data=data, occurred_at=now)], None
 
         return self._update_job_with_retry(job_id, transition)
-
-    def renew_claim(self, job_id: str, worker_id: str) -> Job | None:
-        """Extend a live worker claim without emitting a client event.
-
-        Return the renewed job, or `None` when the claim is inactive, expired,
-        or owned by another worker. An expired lease cannot be resurrected.
-
-        Raises:
-            JobNotFoundError: If the job does not exist.
-            JobOperationContentionError: If concurrent updates exhaust the retry limit.
-        """
-
-        did_renew = False
-
-        def transition(job: Job, now: datetime):
-            """Return a renewed job only while this worker owns the claim."""
-            nonlocal did_renew
-            did_renew = False
-            if (
-                job.state not in {JobState.RUNNING, JobState.CANCELLING}
-                or job.worker_id != worker_id
-                or job.claim_expires_at is None
-                or job.claim_expires_at <= now
-            ):
-                return job, [], None
-            did_renew = True
-            renewed = replace(job, claim_expires_at=now + timedelta(seconds=self._claim_lease_seconds))
-            return renewed, [], None
-
-        renewed = self._update_job_with_retry(job_id, transition)
-        return renewed if did_renew else None
 
     def record_score_and_event(
         self,
@@ -293,6 +295,8 @@ class JobController:
             """Build the terminal completion or cancellation transition."""
             if job.state.terminal:
                 return job, [], None
+            if job.worker_id is not None and not self._store.worker_owns_job(job.worker_id, job.id, now):
+                return job, [], None
             if job.cancel_requested:
                 cancelled = replace(
                     job,
@@ -300,7 +304,6 @@ class JobController:
                     finished_at=now,
                     failure=JobFailure(code="cancelled", message="Optimization cancelled."),
                     queue_position=None,
-                    claim_expires_at=None,
                 )
                 return cancelled, [self._state_event(cancelled, now)], None
             completed = replace(
@@ -311,7 +314,6 @@ class JobController:
                 finished_at=now,
                 artifact_name=artifact.name if artifact is not None else None,
                 queue_position=None,
-                claim_expires_at=None,
             )
             return completed, [self._state_event(completed, now), self._result_event(completed, now)], artifact
 
@@ -331,6 +333,8 @@ class JobController:
             """Build the terminal failure or cancellation transition."""
             if job.state.terminal:
                 return job, [], None
+            if job.worker_id is not None and not self._store.worker_owns_job(job.worker_id, job.id, now):
+                return job, [], None
             if job.cancel_requested:
                 failed = replace(
                     job,
@@ -338,7 +342,6 @@ class JobController:
                     failure=JobFailure(code="cancelled", message="Optimization cancelled."),
                     finished_at=now,
                     queue_position=None,
-                    claim_expires_at=None,
                 )
             else:
                 failed = replace(
@@ -347,7 +350,6 @@ class JobController:
                     failure=failure,
                     finished_at=now,
                     queue_position=None,
-                    claim_expires_at=None,
                 )
             return failed, [self._state_event(failed, now)], None
 
@@ -401,6 +403,7 @@ class JobController:
                 or job.state != JobState.CANCELLING
                 or not job.cancel_requested
                 or job.worker_id != worker_id
+                or not self._store.worker_owns_job(worker_id, job.id, now)
             ):
                 return job, [], None
             cancelled = replace(
@@ -410,7 +413,6 @@ class JobController:
                 failure=JobFailure(code="cancelled", message="Optimization cancelled."),
                 finished_at=now,
                 queue_position=None,
-                claim_expires_at=None,
             )
             return cancelled, [self._state_event(cancelled, now)], None
 
@@ -458,8 +460,10 @@ class JobController:
         """
         job = self.get_job(job_id)
         lost_claim = worker_id is not None and job.worker_id != worker_id
-        expired_claim = worker_id is not None and (
-            job.claim_expires_at is None or job.claim_expires_at <= self._clock()
+        expired_claim = worker_id is not None and not self._store.worker_owns_job(
+            worker_id,
+            job.id,
+            self._clock(),
         )
         return (
             job.state.terminal or lost_claim or expired_claim or job.cancel_requested or job.early_completion_requested
@@ -529,23 +533,21 @@ class JobController:
         return expired_ids
 
     def expire_worker_claims(self) -> list[str]:
-        """Terminate jobs whose worker stopped renewing its execution claim.
+        """Terminate jobs whose owning worker no longer has a live lease.
 
         Return the IDs successfully transitioned during this maintenance pass.
         """
         now = self._clock()
         expired_ids: list[str] = []
-        for candidate in self._store.find_claimed_before(now):
+        for candidate in self._store.find_jobs_without_live_workers(now):
             did_expire = False
 
             def transition(job: Job, transition_time: datetime):
-                """Terminate the job only if its claim remains expired."""
+                """Terminate the job only if worker ownership remains invalid."""
                 nonlocal did_expire
                 did_expire = False
-                if (
-                    job.state not in {JobState.RUNNING, JobState.CANCELLING}
-                    or job.claim_expires_at is None
-                    or job.claim_expires_at > transition_time
+                if job.state not in {JobState.RUNNING, JobState.CANCELLING} or (
+                    job.worker_id is not None and self._store.worker_owns_job(job.worker_id, job.id, transition_time)
                 ):
                     return job, [], None
                 if job.cancel_requested:
@@ -555,7 +557,6 @@ class JobController:
                         failure=JobFailure(code="cancelled", message="Optimization cancelled."),
                         finished_at=transition_time,
                         queue_position=None,
-                        claim_expires_at=None,
                     )
                 else:
                     failed = replace(
@@ -567,7 +568,6 @@ class JobController:
                         ),
                         finished_at=transition_time,
                         queue_position=None,
-                        claim_expires_at=None,
                     )
                 did_expire = True
                 return failed, [self._state_event(failed, transition_time)], None
@@ -576,6 +576,7 @@ class JobController:
             if did_expire:
                 expired_ids.append(expired.id)
                 self._log_terminal_job(expired)
+        self._store.remove_expired_worker_leases(now)
         return expired_ids
 
     def _update_job_with_retry(self, job_id: str, transition: Transition) -> Job:
@@ -592,7 +593,7 @@ class JobController:
             replacement, events, artifact = transition(current, self._clock())
             if replacement is current and not events and artifact is None:
                 return current
-            return self._store.save(replacement, current.revision, events, artifact)
+            return self._store.update_job(replacement, current.revision, events, artifact)
 
         return self._retry_store_write(update)
 

--- a/core/nurse_scheduling/server/jobs/controller.py
+++ b/core/nurse_scheduling/server/jobs/controller.py
@@ -43,6 +43,7 @@ from .models import (
     ServerActivity,
     StoredArtifact,
     StoreLimits,
+    WorkerLease,
 )
 from ..solver_capabilities import solver_supports_finish_now
 
@@ -183,44 +184,47 @@ class JobController:
             raise JobArtifactNotReadyError("The schedule artifact is not ready")
         return self._store.get_artifact(job_id, name)
 
-    def register_worker(self, worker_id: str) -> datetime | None:
-        """Register an idle worker and return its lease expiration."""
+    def register_worker(self, worker_id: str) -> WorkerLease | None:
+        """Register an idle worker and return its lease."""
         now = self._clock()
-        lease_expires_at = now + timedelta(seconds=self._worker_lease_seconds)
-        registered = self._store.register_worker(
-            worker_id,
-            now,
-            lease_expires_at,
+        lease = WorkerLease(
+            worker_id=worker_id,
+            token=uuid4().hex,
+            expires_at=now + timedelta(seconds=self._worker_lease_seconds),
         )
-        return lease_expires_at if registered else None
+        if not self._store.register_worker(lease, now):
+            return None
+        return lease
 
-    def renew_worker(self, worker_id: str) -> datetime | None:
-        """Renew a worker presence lease and return its new expiration."""
+    def renew_worker(self, lease: WorkerLease) -> WorkerLease | None:
+        """Renew a worker presence lease and return its updated value."""
         now = self._clock()
         lease_expires_at = now + timedelta(seconds=self._worker_lease_seconds)
         renewed = self._store.renew_worker(
-            worker_id,
+            lease,
             now,
             lease_expires_at,
         )
-        return lease_expires_at if renewed else None
+        if not renewed:
+            return None
+        return replace(lease, expires_at=lease_expires_at)
 
-    def unregister_worker(self, worker_id: str) -> None:
+    def unregister_worker(self, lease: WorkerLease) -> None:
         """Remove a worker presence lease and active-job association."""
-        self._store.unregister_worker(worker_id)
+        self._store.unregister_worker(lease)
 
     def get_activity(self) -> ServerActivity:
         """Return current aggregate job and worker activity."""
         return self._store.get_activity(self._clock())
 
-    def claim_next_job(self, worker_id: str) -> Job | None:
+    def claim_next_job(self, lease: WorkerLease) -> Job | None:
         """Claim the next queued job for a registered idle worker.
 
         Return the claimed running job, or `None` when the queue is empty.
         """
         now = self._clock()
         job = self._store.claim_next_job(
-            worker_id,
+            lease,
             now,
             self._runtime_identity,
         )
@@ -240,7 +244,7 @@ class JobController:
         event_type: str,
         data: dict[str, Any],
         *,
-        worker_id: str | None = None,
+        lease: WorkerLease | None = None,
     ) -> Job:
         """Persist progress or phase data without changing lifecycle state.
 
@@ -251,14 +255,11 @@ class JobController:
 
         def transition(job: Job, now: datetime) -> tuple[Job, list[JobEvent], StoredArtifact | None]:
             """Append an event only while the reporting worker owns an active job."""
-            if job.state.terminal or (
-                worker_id is not None
-                and (job.worker_id != worker_id or not self._store.worker_owns_job(worker_id, job.id, now))
-            ):
+            if job.state.terminal or (lease is not None and job.worker_id != lease.worker_id):
                 return job, [], None
             return job, [JobEvent(type=event_type, data=data, occurred_at=now)], None
 
-        return self._update_job_with_retry(job_id, transition)
+        return self._update_job_with_retry(job_id, transition, lease=lease)
 
     def record_score_and_event(
         self,
@@ -266,7 +267,7 @@ class JobController:
         score: int,
         data: dict[str, Any],
         *,
-        worker_id: str | None = None,
+        lease: WorkerLease | None = None,
     ) -> Job:
         """Persist the latest score as progress without manufacturing a result.
 
@@ -276,13 +277,15 @@ class JobController:
         """
         payload = dict(data)
         payload["score"] = score
-        return self.record_event(job_id, "job.progressed", payload, worker_id=worker_id)
+        return self.record_event(job_id, "job.progressed", payload, lease=lease)
 
     def complete_job(
         self,
         job_id: str,
         result: OptimizationResult,
         artifact: StoredArtifact | None,
+        *,
+        lease: WorkerLease,
     ) -> Job:
         """Complete a job unless a cancellation request takes precedence.
 
@@ -294,8 +297,6 @@ class JobController:
         def transition(job: Job, now: datetime):
             """Build the terminal completion or cancellation transition."""
             if job.state.terminal:
-                return job, [], None
-            if job.worker_id is not None and not self._store.worker_owns_job(job.worker_id, job.id, now):
                 return job, [], None
             if job.cancel_requested:
                 cancelled = replace(
@@ -317,11 +318,11 @@ class JobController:
             )
             return completed, [self._state_event(completed, now), self._result_event(completed, now)], artifact
 
-        completed = self._update_job_with_retry(job_id, transition)
+        completed = self._update_job_with_retry(job_id, transition, lease=lease)
         self._log_terminal_job(completed)
         return completed
 
-    def fail_job(self, job_id: str, failure: JobFailure) -> Job:
+    def fail_job(self, job_id: str, failure: JobFailure, *, lease: WorkerLease) -> Job:
         """Fail a job unless a cancellation request takes precedence.
 
         Raises:
@@ -332,8 +333,6 @@ class JobController:
         def transition(job: Job, now: datetime):
             """Build the terminal failure or cancellation transition."""
             if job.state.terminal:
-                return job, [], None
-            if job.worker_id is not None and not self._store.worker_owns_job(job.worker_id, job.id, now):
                 return job, [], None
             if job.cancel_requested:
                 failed = replace(
@@ -353,7 +352,7 @@ class JobController:
                 )
             return failed, [self._state_event(failed, now)], None
 
-        failed = self._update_job_with_retry(job_id, transition)
+        failed = self._update_job_with_retry(job_id, transition, lease=lease)
         self._log_terminal_job(failed)
         return failed
 
@@ -393,7 +392,7 @@ class JobController:
         )
         return job
 
-    def complete_cancellation(self, job_id: str, worker_id: str) -> Job:
+    def complete_cancellation(self, job_id: str, lease: WorkerLease) -> Job:
         """Finish cancellation while the reporting worker still owns the job."""
 
         def transition(job: Job, now: datetime):
@@ -402,8 +401,7 @@ class JobController:
                 job.state.terminal
                 or job.state != JobState.CANCELLING
                 or not job.cancel_requested
-                or job.worker_id != worker_id
-                or not self._store.worker_owns_job(worker_id, job.id, now)
+                or job.worker_id != lease.worker_id
             ):
                 return job, [], None
             cancelled = replace(
@@ -416,7 +414,7 @@ class JobController:
             )
             return cancelled, [self._state_event(cancelled, now)], None
 
-        cancelled = self._update_job_with_retry(job_id, transition)
+        cancelled = self._update_job_with_retry(job_id, transition, lease=lease)
         self._log_terminal_job(cancelled)
         return cancelled
 
@@ -449,7 +447,7 @@ class JobController:
 
         return self._update_job_with_retry(job_id, transition)
 
-    def is_stop_requested(self, job_id: str, worker_id: str | None = None) -> bool:
+    def is_stop_requested(self, job_id: str, lease: WorkerLease) -> bool:
         """Return whether a worker should stop executing a job.
 
         Terminal state and lost claim ownership stop stale workers after lease
@@ -459,12 +457,8 @@ class JobController:
             JobNotFoundError: If the job does not exist.
         """
         job = self.get_job(job_id)
-        lost_claim = worker_id is not None and job.worker_id != worker_id
-        expired_claim = worker_id is not None and not self._store.worker_owns_job(
-            worker_id,
-            job.id,
-            self._clock(),
-        )
+        lost_claim = job.worker_id != lease.worker_id
+        expired_claim = not self._store.lease_owns_job(lease, job.id, self._clock())
         return (
             job.state.terminal or lost_claim or expired_claim or job.cancel_requested or job.early_completion_requested
         )
@@ -579,7 +573,13 @@ class JobController:
         self._store.remove_expired_worker_leases(now)
         return expired_ids
 
-    def _update_job_with_retry(self, job_id: str, transition: Transition) -> Job:
+    def _update_job_with_retry(
+        self,
+        job_id: str,
+        transition: Transition,
+        *,
+        lease: WorkerLease | None = None,
+    ) -> Job:
         """Compute and persist a job update, retrying optimistic write conflicts.
 
         Raises:
@@ -590,10 +590,18 @@ class JobController:
         def update() -> Job:
             """Recompute and persist the transition from the latest job revision."""
             current = self._store.get(job_id)
-            replacement, events, artifact = transition(current, self._clock())
+            transition_time = self._clock()
+            replacement, events, artifact = transition(current, transition_time)
             if replacement is current and not events and artifact is None:
                 return current
-            return self._store.update_job(replacement, current.revision, events, artifact)
+            return self._store.update_job(
+                replacement,
+                current.revision,
+                events,
+                artifact,
+                worker_lease=lease,
+                worker_lease_observed_at=transition_time if lease is not None else None,
+            )
 
         return self._retry_store_write(update)
 

--- a/core/nurse_scheduling/server/jobs/models.py
+++ b/core/nurse_scheduling/server/jobs/models.py
@@ -107,8 +107,6 @@ class Job:
     """UTC time at which the job entered a terminal state."""
     worker_id: str | None = None
     """Identity of the worker holding the execution claim."""
-    claim_expires_at: datetime | None = None
-    """UTC deadline after which the worker is presumed lost."""
     queue_position: int | None = None
     """Derived one-based position while the job is queued."""
     result: OptimizationResult | None = None
@@ -157,3 +155,17 @@ class StoreLimits:
     """Maximum queued, running, or cancelling jobs accepted by the store."""
     max_retained: int
     """Maximum total jobs retained, including terminal history."""
+
+
+@dataclass(frozen=True)
+class ServerActivity:
+    """Aggregate job and worker activity exposed by the server."""
+
+    queued_jobs: int
+    """Jobs waiting for a worker."""
+    running_jobs: int
+    """Jobs actively executing."""
+    cancelling_jobs: int
+    """Jobs still occupying a worker while cancellation completes."""
+    online_workers: int
+    """Workers with an unexpired shared lease."""

--- a/core/nurse_scheduling/server/jobs/models.py
+++ b/core/nurse_scheduling/server/jobs/models.py
@@ -158,6 +158,15 @@ class StoreLimits:
 
 
 @dataclass(frozen=True)
+class WorkerLease:
+    """Opaque worker identity used to fence job ownership."""
+
+    worker_id: str
+    token: str
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
 class ServerActivity:
     """Aggregate job and worker activity exposed by the server."""
 

--- a/core/nurse_scheduling/server/jobs/worker.py
+++ b/core/nurse_scheduling/server/jobs/worker.py
@@ -294,7 +294,25 @@ class JobWorker:
                     job.id,
                     self._worker_id,
                 )
-                self._stop.wait(self._claim_poll_seconds)
+                # The execution has ended, but its active-job association may
+                # still be stored. Stop new claims before dropping ownership.
+                self._ready.clear()
+                try:
+                    # Removing the lease makes the abandoned job eligible for
+                    # normal worker-loss expiry. The heartbeat then replaces
+                    # the missing lease and restores readiness.
+                    self._controller.unregister_worker(lease)
+                    self._controller.expire_worker_claims()
+                except Exception:
+                    # Do not keep this loop alive if ownership cleanup is
+                    # uncertain. The heartbeat will observe the stopped loop
+                    # and stop renewing the lease.
+                    server_logger.exception(
+                        "[server:worker] failed to release abandoned job job_id=%s worker_id=%s",
+                        job.id,
+                        self._worker_id,
+                    )
+                    return
             finally:
                 self._executing.clear()
 

--- a/core/nurse_scheduling/server/jobs/worker.py
+++ b/core/nurse_scheduling/server/jobs/worker.py
@@ -27,7 +27,7 @@ from ..config import DEFAULT_TIMEOUT_GRACE_SECONDS
 from ..errors import JobNotFoundError
 from ..solver_capabilities import solver_supports_finish_now
 from .controller import JobController
-from .models import Job, JobFailure, JobState
+from .models import Job, JobFailure, JobState, WorkerLease
 from .process_executor import (
     ProcessControl,
     ProcessStatus,
@@ -80,6 +80,8 @@ class JobWorker:
         """Whether the claim loop is still winding down an owned job."""
         self._lock = threading.Lock()
         """Lock guarding worker-thread creation, inspection, and cleanup."""
+        self._lease: WorkerLease | None = None
+        """Current lease used to claim new work."""
         self._thread: threading.Thread | None = None
         """Daemon claim-loop thread, or `None` when no thread is retained."""
         self._heartbeat_thread: threading.Thread | None = None
@@ -90,15 +92,16 @@ class JobWorker:
         with self._lock:
             if self._thread is not None and self._thread.is_alive():
                 return
-            lease_expires_at = self._controller.register_worker(self._worker_id)
-            if lease_expires_at is None:
+            lease = self._controller.register_worker(self._worker_id)
+            if lease is None:
                 raise RuntimeError(f"Unable to register optimization worker: {self._worker_id}")
+            self._lease = lease
             self._stop.clear()
             self._ready.set()
             self._thread = threading.Thread(target=self._run, name="optimization-job-worker", daemon=True)
             self._heartbeat_thread = threading.Thread(
                 target=self._heartbeat,
-                args=(lease_expires_at,),
+                args=(lease,),
                 name="optimization-worker-heartbeat",
                 daemon=True,
             )
@@ -116,8 +119,11 @@ class JobWorker:
             thread.join(timeout=5)
         if heartbeat_thread is not None:
             heartbeat_thread.join(timeout=5)
+        with self._lock:
+            lease = self._lease
         try:
-            self._controller.unregister_worker(self._worker_id)
+            if lease is not None:
+                self._controller.unregister_worker(lease)
         except Exception:
             server_logger.exception("[server:worker] failed to unregister worker_id=%s", self._worker_id)
         self._ready.clear()
@@ -128,6 +134,8 @@ class JobWorker:
                 heartbeat_thread is None or not heartbeat_thread.is_alive()
             ):
                 self._heartbeat_thread = None
+            if self._lease == lease:
+                self._lease = None
 
     def is_alive(self) -> bool:
         """Return whether the worker thread is currently running."""
@@ -145,10 +153,10 @@ class JobWorker:
                 and self._heartbeat_thread.is_alive()
             )
 
-    def _heartbeat(self, lease_expires_at: datetime) -> None:
+    def _heartbeat(self, lease: WorkerLease) -> None:
         """Renew worker presence and recover safely after an expired lease."""
         while not self._stop.is_set():
-            seconds_until_expiry = (lease_expires_at - datetime.now(timezone.utc)).total_seconds()
+            seconds_until_expiry = (lease.expires_at - datetime.now(timezone.utc)).total_seconds()
             wait_seconds = min(self._worker_heartbeat_seconds, max(0.0, seconds_until_expiry))
             if self._stop.wait(wait_seconds):
                 return
@@ -156,15 +164,21 @@ class JobWorker:
                 self._unregister_stopped_worker()
                 return
 
-            renewed_expires_at = self._renew_worker_lease(lease_expires_at)
-            if renewed_expires_at is not None:
-                lease_expires_at = renewed_expires_at
+            renewed_lease = self._renew_worker_lease(lease)
+            if renewed_lease is not None:
+                with self._lock:
+                    if self._lease == lease:
+                        self._lease = renewed_lease
+                lease = renewed_lease
                 continue
 
-            recovered_expires_at = self._recover_worker_lease()
-            if recovered_expires_at is None:
+            recovered_lease = self._recover_worker_lease(lease)
+            if recovered_lease is None:
                 return
-            lease_expires_at = recovered_expires_at
+            with self._lock:
+                self._lease = recovered_lease
+            self._ready.set()
+            lease = recovered_lease
 
     def _claim_loop_is_alive(self) -> bool:
         """Return whether the job claim loop is still running."""
@@ -174,26 +188,44 @@ class JobWorker:
     def _unregister_stopped_worker(self) -> None:
         """Clear readiness and unregister after the claim loop exits."""
         self._ready.clear()
+        with self._lock:
+            lease = self._lease
         try:
-            self._controller.unregister_worker(self._worker_id)
+            if lease is not None:
+                self._controller.unregister_worker(lease)
         except Exception:
             server_logger.exception(
                 "[server:worker] failed to unregister stopped worker_id=%s",
                 self._worker_id,
             )
+        with self._lock:
+            if self._lease == lease:
+                self._lease = None
 
-    def _renew_worker_lease(self, lease_expires_at: datetime) -> datetime | None:
+    def _renew_worker_lease(self, lease: WorkerLease) -> WorkerLease | None:
         """Renew once, retaining the current lease through a brief store outage."""
         try:
-            return self._controller.renew_worker(self._worker_id)
+            return self._controller.renew_worker(lease)
         except Exception:
             server_logger.exception("[server:worker] failed to renew worker_id=%s", self._worker_id)
-            if datetime.now(timezone.utc) < lease_expires_at:
-                return lease_expires_at
+            if datetime.now(timezone.utc) < lease.expires_at:
+                return lease
             return None
 
-    def _recover_worker_lease(self) -> datetime | None:
-        """Expire abandoned work and re-register after lease loss."""
+    def _recover_worker_lease(self, lease: WorkerLease) -> WorkerLease | None:
+        """Reconcile an uncertain renewal before replacing a lost lease."""
+        try:
+            renewed_lease = self._controller.renew_worker(lease)
+        except Exception:
+            server_logger.exception(
+                "[server:worker] failed to reconcile worker lease worker_id=%s",
+                self._worker_id,
+            )
+        else:
+            if renewed_lease is not None:
+                server_logger.info("[server:worker] worker lease reconciled worker_id=%s", self._worker_id)
+                return renewed_lease
+
         self._ready.clear()
         server_logger.error("[server:worker] worker lease expired worker_id=%s", self._worker_id)
         while not self._stop.is_set():
@@ -203,11 +235,10 @@ class JobWorker:
             try:
                 self._controller.expire_worker_claims()
                 if not self._executing.is_set():
-                    lease_expires_at = self._controller.register_worker(self._worker_id)
-                    if lease_expires_at is not None:
-                        self._ready.set()
+                    recovered_lease = self._controller.register_worker(self._worker_id)
+                    if recovered_lease is not None:
                         server_logger.info("[server:worker] worker lease recovered worker_id=%s", self._worker_id)
-                        return lease_expires_at
+                        return recovered_lease
             except Exception:
                 server_logger.exception("[server:worker] failed to recover worker_id=%s", self._worker_id)
             self._stop.wait(self._claim_poll_seconds)
@@ -222,8 +253,13 @@ class JobWorker:
             if not self._ready.is_set():
                 self._stop.wait(self._claim_poll_seconds)
                 continue
+            with self._lock:
+                lease = self._lease
+            if lease is None:
+                self._stop.wait(self._claim_poll_seconds)
+                continue
             try:
-                job = self._controller.claim_next_job(self._worker_id)
+                job = self._controller.claim_next_job(lease)
             except Exception:
                 server_logger.exception("[server:worker] failed to claim job worker_id=%s", self._worker_id)
                 self._stop.wait(self._claim_poll_seconds)
@@ -233,7 +269,7 @@ class JobWorker:
                 continue
             self._executing.set()
             try:
-                self._execute(job)
+                self._execute(job, lease)
             except Exception:
                 server_logger.exception(
                     "[server:worker] failed to report execution outcome job_id=%s worker_id=%s",
@@ -244,7 +280,7 @@ class JobWorker:
             finally:
                 self._executing.clear()
 
-    def _execute(self, job: Job) -> None:
+    def _execute(self, job: Job, lease: WorkerLease) -> None:
         """Execute one claimed job and report its progress and outcome."""
         content = b""
         # Stops the control thread and aborts the child after ownership loss.
@@ -261,18 +297,18 @@ class JobWorker:
             def publish(event_type: str, data: dict, score: int | None) -> None:
                 """Persist one runner event and its score when available."""
                 if score is None:
-                    self._controller.record_event(job.id, event_type, data, worker_id=self._worker_id)
+                    self._controller.record_event(job.id, event_type, data, lease=lease)
                 else:
-                    self._controller.record_score_and_event(job.id, score, data, worker_id=self._worker_id)
+                    self._controller.record_score_and_event(job.id, score, data, lease=lease)
 
             def watch_controls() -> None:
                 """Poll cancellation, finish-now, and ownership controls."""
                 stop_check_error_logged = False
                 while not monitor_stop.is_set():
                     try:
-                        if self._controller.is_stop_requested(job.id, self._worker_id):
+                        if self._controller.is_stop_requested(job.id, lease):
                             current = self._controller.get_job(job.id)
-                            if current.state.terminal or current.worker_id != self._worker_id:
+                            if current.state.terminal or current.worker_id != lease.worker_id:
                                 monitor_stop.set()
                                 return
                             if current.cancel_requested:
@@ -335,13 +371,14 @@ class JobWorker:
                     job.id,
                     process_result.output.result,
                     process_result.output.artifact,
+                    lease=lease,
                 )
             elif process_result.status is ProcessStatus.FAILED:
                 if process_result.failure is None:
                     raise RuntimeError("Failed optimization process has no failure")
-                self._controller.fail_job(job.id, process_result.failure)
+                self._controller.fail_job(job.id, process_result.failure, lease=lease)
             elif process_result.status is ProcessStatus.CANCELLED:
-                self._controller.complete_cancellation(job.id, self._worker_id)
+                self._controller.complete_cancellation(job.id, lease)
             elif process_result.status is ProcessStatus.ABORTED:
                 server_logger.info(
                     "[server:worker] stopped child execution job_id=%s worker_id=%s",
@@ -355,7 +392,7 @@ class JobWorker:
         except Exception as error:
             failure = JobFailure(code="optimization_failed", message=self._unexpected_error_formatter(error))
             try:
-                failed = self._controller.fail_job(job.id, failure)
+                failed = self._controller.fail_job(job.id, failure, lease=lease)
             except Exception:
                 try:
                     capture_optimize_exception(job, content, error)

--- a/core/nurse_scheduling/server/jobs/worker.py
+++ b/core/nurse_scheduling/server/jobs/worker.py
@@ -20,6 +20,7 @@
 import logging
 import threading
 from collections.abc import Callable
+from datetime import datetime, timezone
 
 from ...sentry import capture_optimize_exception
 from ..config import DEFAULT_TIMEOUT_GRACE_SECONDS
@@ -50,7 +51,7 @@ class JobWorker:
         *,
         worker_id: str,
         claim_poll_seconds: float,
-        claim_lease_seconds: float,
+        worker_lease_seconds: float,
         timeout_grace_seconds: float = DEFAULT_TIMEOUT_GRACE_SECONDS,
         unexpected_error_formatter: Callable[[Exception], str] = str,
     ):
@@ -65,25 +66,44 @@ class JobWorker:
         """Stable identity recorded on jobs claimed by this worker."""
         self._claim_poll_seconds = claim_poll_seconds
         """Delay between claim attempts and after recoverable loop errors."""
-        self._claim_heartbeat_seconds = claim_lease_seconds / 3
-        """Claim-renewal interval set to one third of the lease for retry margin."""
+        self._worker_lease_seconds = worker_lease_seconds
+        """Maximum time this worker remains live without a successful heartbeat."""
+        self._worker_heartbeat_seconds = worker_lease_seconds / 3
+        """Worker-renewal interval set to one third of the lease for retry margin."""
         self._unexpected_error_formatter = unexpected_error_formatter
         """Formatter used to produce unexpected failure messages."""
         self._stop = threading.Event()
         """Signal that stops claiming jobs and terminates the active child."""
+        self._ready = threading.Event()
+        """Whether this worker currently holds a live registered lease."""
+        self._executing = threading.Event()
+        """Whether the claim loop is still winding down an owned job."""
         self._lock = threading.Lock()
         """Lock guarding worker-thread creation, inspection, and cleanup."""
         self._thread: threading.Thread | None = None
         """Daemon claim-loop thread, or `None` when no thread is retained."""
+        self._heartbeat_thread: threading.Thread | None = None
+        """Always-running worker-presence heartbeat thread."""
 
     def start(self) -> None:
-        """Start the daemon claim loop unless it is already running."""
+        """Register this worker and start its claim and heartbeat loops."""
         with self._lock:
             if self._thread is not None and self._thread.is_alive():
                 return
+            lease_expires_at = self._controller.register_worker(self._worker_id)
+            if lease_expires_at is None:
+                raise RuntimeError(f"Unable to register optimization worker: {self._worker_id}")
             self._stop.clear()
+            self._ready.set()
             self._thread = threading.Thread(target=self._run, name="optimization-job-worker", daemon=True)
+            self._heartbeat_thread = threading.Thread(
+                target=self._heartbeat,
+                args=(lease_expires_at,),
+                name="optimization-worker-heartbeat",
+                daemon=True,
+            )
             self._thread.start()
+            self._heartbeat_thread.start()
         server_logger.info("[server:worker] started worker_id=%s", self._worker_id)
 
     def stop(self) -> None:
@@ -91,16 +111,107 @@ class JobWorker:
         self._stop.set()
         with self._lock:
             thread = self._thread
+            heartbeat_thread = self._heartbeat_thread
         if thread is not None:
             thread.join(timeout=5)
+        if heartbeat_thread is not None:
+            heartbeat_thread.join(timeout=5)
+        try:
+            self._controller.unregister_worker(self._worker_id)
+        except Exception:
+            server_logger.exception("[server:worker] failed to unregister worker_id=%s", self._worker_id)
+        self._ready.clear()
         with self._lock:
             if self._thread is thread and (thread is None or not thread.is_alive()):
                 self._thread = None
+            if self._heartbeat_thread is heartbeat_thread and (
+                heartbeat_thread is None or not heartbeat_thread.is_alive()
+            ):
+                self._heartbeat_thread = None
 
     def is_alive(self) -> bool:
         """Return whether the worker thread is currently running."""
         with self._lock:
             return self._thread is not None and self._thread.is_alive()
+
+    def is_ready(self) -> bool:
+        """Return whether both worker loops are alive with a registered lease."""
+        with self._lock:
+            return bool(
+                self._ready.is_set()
+                and self._thread is not None
+                and self._thread.is_alive()
+                and self._heartbeat_thread is not None
+                and self._heartbeat_thread.is_alive()
+            )
+
+    def _heartbeat(self, lease_expires_at: datetime) -> None:
+        """Renew worker presence and recover safely after an expired lease."""
+        while not self._stop.is_set():
+            seconds_until_expiry = (lease_expires_at - datetime.now(timezone.utc)).total_seconds()
+            wait_seconds = min(self._worker_heartbeat_seconds, max(0.0, seconds_until_expiry))
+            if self._stop.wait(wait_seconds):
+                return
+            if not self._claim_loop_is_alive():
+                self._unregister_stopped_worker()
+                return
+
+            renewed_expires_at = self._renew_worker_lease(lease_expires_at)
+            if renewed_expires_at is not None:
+                lease_expires_at = renewed_expires_at
+                continue
+
+            recovered_expires_at = self._recover_worker_lease()
+            if recovered_expires_at is None:
+                return
+            lease_expires_at = recovered_expires_at
+
+    def _claim_loop_is_alive(self) -> bool:
+        """Return whether the job claim loop is still running."""
+        with self._lock:
+            return self._thread is not None and self._thread.is_alive()
+
+    def _unregister_stopped_worker(self) -> None:
+        """Clear readiness and unregister after the claim loop exits."""
+        self._ready.clear()
+        try:
+            self._controller.unregister_worker(self._worker_id)
+        except Exception:
+            server_logger.exception(
+                "[server:worker] failed to unregister stopped worker_id=%s",
+                self._worker_id,
+            )
+
+    def _renew_worker_lease(self, lease_expires_at: datetime) -> datetime | None:
+        """Renew once, retaining the current lease through a brief store outage."""
+        try:
+            return self._controller.renew_worker(self._worker_id)
+        except Exception:
+            server_logger.exception("[server:worker] failed to renew worker_id=%s", self._worker_id)
+            if datetime.now(timezone.utc) < lease_expires_at:
+                return lease_expires_at
+            return None
+
+    def _recover_worker_lease(self) -> datetime | None:
+        """Expire abandoned work and re-register after lease loss."""
+        self._ready.clear()
+        server_logger.error("[server:worker] worker lease expired worker_id=%s", self._worker_id)
+        while not self._stop.is_set():
+            if not self._claim_loop_is_alive():
+                self._unregister_stopped_worker()
+                return None
+            try:
+                self._controller.expire_worker_claims()
+                if not self._executing.is_set():
+                    lease_expires_at = self._controller.register_worker(self._worker_id)
+                    if lease_expires_at is not None:
+                        self._ready.set()
+                        server_logger.info("[server:worker] worker lease recovered worker_id=%s", self._worker_id)
+                        return lease_expires_at
+            except Exception:
+                server_logger.exception("[server:worker] failed to recover worker_id=%s", self._worker_id)
+            self._stop.wait(self._claim_poll_seconds)
+        return None
 
     def _run(self) -> None:
         """Claim and execute jobs until shutdown is requested.
@@ -108,6 +219,9 @@ class JobWorker:
         Recoverable claim and reporting failures are logged before retrying.
         """
         while not self._stop.is_set():
+            if not self._ready.is_set():
+                self._stop.wait(self._claim_poll_seconds)
+                continue
             try:
                 job = self._controller.claim_next_job(self._worker_id)
             except Exception:
@@ -117,6 +231,7 @@ class JobWorker:
             if job is None:
                 self._stop.wait(self._claim_poll_seconds)
                 continue
+            self._executing.set()
             try:
                 self._execute(job)
             except Exception:
@@ -126,39 +241,19 @@ class JobWorker:
                     self._worker_id,
                 )
                 self._stop.wait(self._claim_poll_seconds)
+            finally:
+                self._executing.clear()
 
     def _execute(self, job: Job) -> None:
         """Execute one claimed job and report its progress and outcome."""
         content = b""
-        # Stops the heartbeat and control threads, and aborts the child after claim loss.
-        # Its waits set how often the worker renews the claim and checks controls.
+        # Stops the control thread and aborts the child after ownership loss.
         monitor_stop = threading.Event()
         # Asks the solver to stop while preserving its current result.
         finish_now_requested = threading.Event()
         # Cancels the job and discards its result, forcing termination if needed.
         cancellation_requested = threading.Event()
 
-        def renew_claim() -> None:
-            """Renew the worker claim until execution ends or the job disappears."""
-            while not monitor_stop.wait(self._claim_heartbeat_seconds):
-                try:
-                    renewed = self._controller.renew_claim(job.id, self._worker_id)
-                    if renewed is None or renewed.state.terminal or renewed.worker_id != self._worker_id:
-                        monitor_stop.set()
-                        return
-                except JobNotFoundError:
-                    monitor_stop.set()
-                    return
-                except Exception:
-                    server_logger.exception("[server:worker] failed to renew claim job_id=%s", job.id)
-
-        # Lease renewal runs separately because optimization blocks this worker thread.
-        heartbeat_thread = threading.Thread(
-            target=renew_claim,
-            name=f"optimization-job-heartbeat-{job.id}",
-            daemon=True,
-        )
-        heartbeat_thread.start()
         control_thread: threading.Thread | None = None
         try:
             content = self._controller.get_input(job.id)
@@ -193,7 +288,7 @@ class JobWorker:
                         monitor_stop.set()
                         return
                     except Exception:
-                        # Claim renewal logs store outages and keeps retrying.
+                        # The worker heartbeat logs store outages and keeps retrying.
                         if not stop_check_error_logged:
                             server_logger.exception(
                                 "[server:worker] failed to check stop request job_id=%s",
@@ -213,6 +308,8 @@ class JobWorker:
             def process_control() -> ProcessControl | None:
                 """Return the highest-priority control for the optimization child."""
                 if monitor_stop.is_set():
+                    return ProcessControl.ABORT
+                if not self._ready.is_set():
                     return ProcessControl.ABORT
                 if cancellation_requested.is_set():
                     return ProcessControl.CANCEL
@@ -289,4 +386,3 @@ class JobWorker:
             monitor_stop.set()
             if control_thread is not None:
                 control_thread.join(timeout=1)
-            heartbeat_thread.join(timeout=1)

--- a/core/nurse_scheduling/server/jobs/worker.py
+++ b/core/nurse_scheduling/server/jobs/worker.py
@@ -79,7 +79,7 @@ class JobWorker:
         self._executing = threading.Event()
         """Whether the claim loop is still winding down an owned job."""
         self._lock = threading.Lock()
-        """Lock guarding worker-thread creation, inspection, and cleanup."""
+        """Lock guarding the current lease and worker-thread state."""
         self._lease: WorkerLease | None = None
         """Current lease used to claim new work."""
         self._thread: threading.Thread | None = None
@@ -119,8 +119,7 @@ class JobWorker:
             thread.join(timeout=5)
         if heartbeat_thread is not None:
             heartbeat_thread.join(timeout=5)
-        with self._lock:
-            lease = self._lease
+        lease = self._pop_lease()
         try:
             if lease is not None:
                 self._controller.unregister_worker(lease)
@@ -134,8 +133,6 @@ class JobWorker:
                 heartbeat_thread is None or not heartbeat_thread.is_alive()
             ):
                 self._heartbeat_thread = None
-            if self._lease == lease:
-                self._lease = None
 
     def is_alive(self) -> bool:
         """Return whether the worker thread is currently running."""
@@ -153,6 +150,26 @@ class JobWorker:
                 and self._heartbeat_thread.is_alive()
             )
 
+    def _current_lease(self) -> WorkerLease | None:
+        """Return the lease currently available for new claims."""
+        with self._lock:
+            return self._lease
+
+    def _replace_lease(self, expected: WorkerLease, replacement: WorkerLease) -> bool:
+        """Replace the current lease unless shutdown or another replacement won."""
+        with self._lock:
+            if self._stop.is_set() or self._lease != expected:
+                return False
+            self._lease = replacement
+            return True
+
+    def _pop_lease(self) -> WorkerLease | None:
+        """Atomically clear and return the current lease."""
+        with self._lock:
+            lease = self._lease
+            self._lease = None
+            return lease
+
     def _heartbeat(self, lease: WorkerLease) -> None:
         """Renew worker presence and recover safely after an expired lease."""
         while not self._stop.is_set():
@@ -166,17 +183,23 @@ class JobWorker:
 
             renewed_lease = self._renew_worker_lease(lease)
             if renewed_lease is not None:
-                with self._lock:
-                    if self._lease == lease:
-                        self._lease = renewed_lease
+                if not self._replace_lease(lease, renewed_lease):
+                    return
                 lease = renewed_lease
                 continue
 
             recovered_lease = self._recover_worker_lease(lease)
             if recovered_lease is None:
                 return
-            with self._lock:
-                self._lease = recovered_lease
+            if not self._replace_lease(lease, recovered_lease):
+                try:
+                    self._controller.unregister_worker(recovered_lease)
+                except Exception:
+                    server_logger.exception(
+                        "[server:worker] failed to discard recovered lease worker_id=%s",
+                        self._worker_id,
+                    )
+                return
             self._ready.set()
             lease = recovered_lease
 
@@ -188,8 +211,7 @@ class JobWorker:
     def _unregister_stopped_worker(self) -> None:
         """Clear readiness and unregister after the claim loop exits."""
         self._ready.clear()
-        with self._lock:
-            lease = self._lease
+        lease = self._pop_lease()
         try:
             if lease is not None:
                 self._controller.unregister_worker(lease)
@@ -198,9 +220,6 @@ class JobWorker:
                 "[server:worker] failed to unregister stopped worker_id=%s",
                 self._worker_id,
             )
-        with self._lock:
-            if self._lease == lease:
-                self._lease = None
 
     def _renew_worker_lease(self, lease: WorkerLease) -> WorkerLease | None:
         """Renew once, retaining the current lease through a brief store outage."""
@@ -253,8 +272,7 @@ class JobWorker:
             if not self._ready.is_set():
                 self._stop.wait(self._claim_poll_seconds)
                 continue
-            with self._lock:
-                lease = self._lease
+            lease = self._current_lease()
             if lease is None:
                 self._stop.wait(self._claim_poll_seconds)
                 continue

--- a/core/nurse_scheduling/server/maintenance.py
+++ b/core/nurse_scheduling/server/maintenance.py
@@ -27,12 +27,12 @@ server_logger = logging.getLogger("nurse_scheduling.server")
 
 
 class JobMaintenance:
-    """Periodically expire lost-worker claims and retained job history."""
+    """Periodically expire lost-worker jobs, leases, and retained history."""
 
     def __init__(self, controller: JobController, *, interval_seconds: float):
         """Configure periodic job cleanup without starting its thread."""
         self._controller = controller
-        """Controller that expires lost-worker claims and retained job history."""
+        """Controller that expires lost-worker jobs, leases, and retained history."""
         self._interval_seconds = interval_seconds
         """Delay between maintenance passes."""
         self._stop = threading.Event()
@@ -58,7 +58,7 @@ class JobMaintenance:
             self._thread = None
 
     def _run(self) -> None:
-        """Apply claim expiry and retention cleanup at each interval.
+        """Apply worker lease and retention cleanup at each interval.
 
         Failures are logged without terminating future maintenance passes.
         """

--- a/core/nurse_scheduling/server/stores/memory.py
+++ b/core/nurse_scheduling/server/stores/memory.py
@@ -30,7 +30,7 @@ from ..errors import (
     JobNotFoundError,
     StoreWriteConflictError,
 )
-from ..jobs.models import Job, JobEvent, JobState, ServerActivity, StoredArtifact, StoreLimits
+from ..jobs.models import Job, JobEvent, JobState, ServerActivity, StoredArtifact, StoreLimits, WorkerLease
 
 
 @dataclass
@@ -53,6 +53,7 @@ class _MemoryJobRecord:
 class _MemoryWorkerLease:
     """Process-local worker presence and exclusive job association."""
 
+    token: str
     expires_at: datetime
     active_job_id: str | None = None
 
@@ -161,7 +162,7 @@ class MemoryJobStore:
 
     def claim_next_job(
         self,
-        worker_id: str,
+        lease: WorkerLease,
         started_at: datetime,
         runtime_identity: Mapping[str, str] | None = None,
     ) -> Job | None:
@@ -170,8 +171,13 @@ class MemoryJobStore:
         Return the claimed running job, or `None` when the queue is empty.
         """
         with self._changed:
-            worker = self._workers.get(worker_id)
-            if worker is None or worker.expires_at <= started_at or worker.active_job_id is not None:
+            worker = self._workers.get(lease.worker_id)
+            if (
+                worker is None
+                or worker.token != lease.token
+                or worker.expires_at <= started_at
+                or worker.active_job_id is not None
+            ):
                 return None
             queued = sorted(
                 (record for record in self._records.values() if record.job.state == JobState.QUEUED),
@@ -184,7 +190,7 @@ class MemoryJobStore:
                 record.job,
                 state=JobState.RUNNING,
                 started_at=started_at,
-                worker_id=worker_id,
+                worker_id=lease.worker_id,
                 queue_position=None,
                 revision=record.job.revision + 1,
             )
@@ -200,7 +206,7 @@ class MemoryJobStore:
                             "queue_position": None,
                             "cancel_requested": False,
                             "early_completion_requested": False,
-                            "worker_id": worker_id,
+                            "worker_id": lease.worker_id,
                             **({"runtime": dict(runtime_identity)} if runtime_identity is not None else {}),
                         },
                         occurred_at=started_at,
@@ -212,30 +218,32 @@ class MemoryJobStore:
             self._changed.notify_all()
             return claimed
 
-    def register_worker(self, worker_id: str, registered_at: datetime, lease_expires_at: datetime) -> bool:
+    def register_worker(self, lease: WorkerLease, registered_at: datetime) -> bool:
         """Register an idle worker without replacing a live or unresolved lease."""
         with self._changed:
-            existing = self._workers.get(worker_id)
+            existing = self._workers.get(lease.worker_id)
             if existing is not None and (existing.expires_at > registered_at or existing.active_job_id is not None):
                 return False
-            self._workers[worker_id] = _MemoryWorkerLease(expires_at=lease_expires_at)
+            self._workers[lease.worker_id] = _MemoryWorkerLease(token=lease.token, expires_at=lease.expires_at)
             self._changed.notify_all()
             return True
 
-    def renew_worker(self, worker_id: str, renewed_at: datetime, lease_expires_at: datetime) -> bool:
+    def renew_worker(self, lease: WorkerLease, renewed_at: datetime, lease_expires_at: datetime) -> bool:
         """Renew an existing lease only before its current expiry."""
         with self._changed:
-            worker = self._workers.get(worker_id)
-            if worker is None or worker.expires_at <= renewed_at:
+            worker = self._workers.get(lease.worker_id)
+            if worker is None or worker.token != lease.token or worker.expires_at <= renewed_at:
                 return False
             worker.expires_at = lease_expires_at
             self._changed.notify_all()
             return True
 
-    def unregister_worker(self, worker_id: str) -> None:
-        """Remove worker presence and ownership state."""
+    def unregister_worker(self, lease: WorkerLease) -> None:
+        """Remove matching worker presence and ownership state."""
         with self._changed:
-            self._workers.pop(worker_id, None)
+            worker = self._workers.get(lease.worker_id)
+            if worker is not None and worker.token == lease.token:
+                del self._workers[lease.worker_id]
             self._changed.notify_all()
 
     def worker_owns_job(self, worker_id: str, job_id: str, observed_at: datetime) -> bool:
@@ -243,6 +251,17 @@ class MemoryJobStore:
         with self._lock:
             worker = self._workers.get(worker_id)
             return bool(worker is not None and worker.expires_at > observed_at and worker.active_job_id == job_id)
+
+    def lease_owns_job(self, lease: WorkerLease, job_id: str, observed_at: datetime) -> bool:
+        """Return whether this exact live lease is associated with the job."""
+        with self._lock:
+            worker = self._workers.get(lease.worker_id)
+            return bool(
+                worker is not None
+                and worker.token == lease.token
+                and worker.expires_at > observed_at
+                and worker.active_job_id == job_id
+            )
 
     def get_activity(self, observed_at: datetime) -> ServerActivity:
         """Return aggregate job states and unexpired worker leases."""
@@ -261,8 +280,15 @@ class MemoryJobStore:
         expected_revision: int,
         events: Sequence[JobEvent],
         artifact: StoredArtifact | None = None,
+        *,
+        worker_lease: WorkerLease | None = None,
+        worker_lease_observed_at: datetime | None = None,
     ) -> Job:
-        """Update a job only if no concurrent update has occurred.
+        """Update a job if its revision and optional worker lease still match.
+
+        Omit `worker_lease` only for server-authorized API or maintenance
+        transitions. Worker-originated updates must include the lease and its
+        observation time.
 
         Raises:
             JobNotFoundError: If the job does not exist.
@@ -272,6 +298,18 @@ class MemoryJobStore:
             record = self._record(job.id)
             if record.job.revision != expected_revision:
                 raise StoreWriteConflictError(f"Job revision changed: {job.id}")
+            if worker_lease is not None:
+                if worker_lease_observed_at is None:
+                    raise ValueError("worker_lease_observed_at is required with a worker lease")
+                worker = self._workers.get(worker_lease.worker_id)
+                if (
+                    record.job.worker_id != worker_lease.worker_id
+                    or worker is None
+                    or worker.token != worker_lease.token
+                    or worker.expires_at <= worker_lease_observed_at
+                    or worker.active_job_id != job.id
+                ):
+                    return self._with_queue_position(record.job)
             was_queued = record.job.state == JobState.QUEUED
             updated_job = replace(job, revision=expected_revision + 1, queue_position=None)
             record.job = updated_job

--- a/core/nurse_scheduling/server/stores/memory.py
+++ b/core/nurse_scheduling/server/stores/memory.py
@@ -160,6 +160,17 @@ class MemoryJobStore:
                 raise JobArtifactNotFoundError("Job artifact was not found")
             return artifact
 
+    def _get_worker_for_live_lease_locked(
+        self,
+        lease: WorkerLease,
+        observed_at: datetime,
+    ) -> _MemoryWorkerLease | None:
+        """Return the matching live lease while the caller holds `_lock`."""
+        worker = self._workers.get(lease.worker_id)
+        if worker is None or worker.token != lease.token or worker.expires_at <= observed_at:
+            return None
+        return worker
+
     def claim_next_job(
         self,
         lease: WorkerLease,
@@ -171,13 +182,8 @@ class MemoryJobStore:
         Return the claimed running job, or `None` when the queue is empty.
         """
         with self._changed:
-            worker = self._workers.get(lease.worker_id)
-            if (
-                worker is None
-                or worker.token != lease.token
-                or worker.expires_at <= started_at
-                or worker.active_job_id is not None
-            ):
+            worker = self._get_worker_for_live_lease_locked(lease, started_at)
+            if worker is None or worker.active_job_id is not None:
                 return None
             queued = sorted(
                 (record for record in self._records.values() if record.job.state == JobState.QUEUED),
@@ -231,8 +237,8 @@ class MemoryJobStore:
     def renew_worker(self, lease: WorkerLease, renewed_at: datetime, lease_expires_at: datetime) -> bool:
         """Renew an existing lease only before its current expiry."""
         with self._changed:
-            worker = self._workers.get(lease.worker_id)
-            if worker is None or worker.token != lease.token or worker.expires_at <= renewed_at:
+            worker = self._get_worker_for_live_lease_locked(lease, renewed_at)
+            if worker is None:
                 return False
             worker.expires_at = lease_expires_at
             self._changed.notify_all()
@@ -246,7 +252,7 @@ class MemoryJobStore:
                 del self._workers[lease.worker_id]
             self._changed.notify_all()
 
-    def worker_owns_job(self, worker_id: str, job_id: str, observed_at: datetime) -> bool:
+    def live_worker_owns_job(self, worker_id: str, job_id: str, observed_at: datetime) -> bool:
         """Return whether a live worker is associated with the job."""
         with self._lock:
             worker = self._workers.get(worker_id)
@@ -255,13 +261,8 @@ class MemoryJobStore:
     def lease_owns_job(self, lease: WorkerLease, job_id: str, observed_at: datetime) -> bool:
         """Return whether this exact live lease is associated with the job."""
         with self._lock:
-            worker = self._workers.get(lease.worker_id)
-            return bool(
-                worker is not None
-                and worker.token == lease.token
-                and worker.expires_at > observed_at
-                and worker.active_job_id == job_id
-            )
+            worker = self._get_worker_for_live_lease_locked(lease, observed_at)
+            return worker is not None and worker.active_job_id == job_id
 
     def get_activity(self, observed_at: datetime) -> ServerActivity:
         """Return aggregate job states and unexpired worker leases."""
@@ -301,14 +302,8 @@ class MemoryJobStore:
             if worker_lease is not None:
                 if worker_lease_observed_at is None:
                     raise ValueError("worker_lease_observed_at is required with a worker lease")
-                worker = self._workers.get(worker_lease.worker_id)
-                if (
-                    record.job.worker_id != worker_lease.worker_id
-                    or worker is None
-                    or worker.token != worker_lease.token
-                    or worker.expires_at <= worker_lease_observed_at
-                    or worker.active_job_id != job.id
-                ):
+                worker = self._get_worker_for_live_lease_locked(worker_lease, worker_lease_observed_at)
+                if record.job.worker_id != worker_lease.worker_id or worker is None or worker.active_job_id != job.id:
                     return self._with_queue_position(record.job)
             was_queued = record.job.state == JobState.QUEUED
             updated_job = replace(job, revision=expected_revision + 1, queue_position=None)
@@ -395,7 +390,7 @@ class MemoryJobStore:
                 if record.job.state in {JobState.RUNNING, JobState.CANCELLING}
                 and (
                     record.job.worker_id is None
-                    or not self.worker_owns_job(record.job.worker_id, record.job.id, observed_at)
+                    or not self.live_worker_owns_job(record.job.worker_id, record.job.id, observed_at)
                 )
             ]
 

--- a/core/nurse_scheduling/server/stores/memory.py
+++ b/core/nurse_scheduling/server/stores/memory.py
@@ -30,7 +30,7 @@ from ..errors import (
     JobNotFoundError,
     StoreWriteConflictError,
 )
-from ..jobs.models import Job, JobEvent, JobState, StoredArtifact, StoreLimits
+from ..jobs.models import Job, JobEvent, JobState, ServerActivity, StoredArtifact, StoreLimits
 
 
 @dataclass
@@ -49,6 +49,14 @@ class _MemoryJobRecord:
     """Monotonic integer assigned to the next appended event."""
 
 
+@dataclass
+class _MemoryWorkerLease:
+    """Process-local worker presence and exclusive job association."""
+
+    expires_at: datetime
+    active_job_id: str | None = None
+
+
 class MemoryJobStore:
     """Thread-safe process-local job metadata, queue, events, and blobs."""
 
@@ -62,6 +70,8 @@ class MemoryJobStore:
         """Opaque identity unique to this process-local store."""
         self._records: dict[str, _MemoryJobRecord] = {}
         """Job records indexed by job ID."""
+        self._workers: dict[str, _MemoryWorkerLease] = {}
+        """Worker leases indexed by worker ID."""
         self._max_events_per_job = max_events_per_job
         """Maximum replayable events retained for any one job."""
         self._lock = threading.RLock()
@@ -149,11 +159,10 @@ class MemoryJobStore:
                 raise JobArtifactNotFoundError("Job artifact was not found")
             return artifact
 
-    def claim_next(
+    def claim_next_job(
         self,
         worker_id: str,
         started_at: datetime,
-        claim_expires_at: datetime,
         runtime_identity: Mapping[str, str] | None = None,
     ) -> Job | None:
         """Atomically assign the oldest queued job to a worker.
@@ -161,6 +170,9 @@ class MemoryJobStore:
         Return the claimed running job, or `None` when the queue is empty.
         """
         with self._changed:
+            worker = self._workers.get(worker_id)
+            if worker is None or worker.expires_at <= started_at or worker.active_job_id is not None:
+                return None
             queued = sorted(
                 (record for record in self._records.values() if record.job.state == JobState.QUEUED),
                 key=lambda record: (record.job.created_at, record.job.id),
@@ -173,10 +185,10 @@ class MemoryJobStore:
                 state=JobState.RUNNING,
                 started_at=started_at,
                 worker_id=worker_id,
-                claim_expires_at=claim_expires_at,
                 queue_position=None,
                 revision=record.job.revision + 1,
             )
+            worker.active_job_id = claimed.id
             record.job = claimed
             self._append_events(
                 record,
@@ -200,14 +212,57 @@ class MemoryJobStore:
             self._changed.notify_all()
             return claimed
 
-    def save(
+    def register_worker(self, worker_id: str, registered_at: datetime, lease_expires_at: datetime) -> bool:
+        """Register an idle worker without replacing a live or unresolved lease."""
+        with self._changed:
+            existing = self._workers.get(worker_id)
+            if existing is not None and (existing.expires_at > registered_at or existing.active_job_id is not None):
+                return False
+            self._workers[worker_id] = _MemoryWorkerLease(expires_at=lease_expires_at)
+            self._changed.notify_all()
+            return True
+
+    def renew_worker(self, worker_id: str, renewed_at: datetime, lease_expires_at: datetime) -> bool:
+        """Renew an existing lease only before its current expiry."""
+        with self._changed:
+            worker = self._workers.get(worker_id)
+            if worker is None or worker.expires_at <= renewed_at:
+                return False
+            worker.expires_at = lease_expires_at
+            self._changed.notify_all()
+            return True
+
+    def unregister_worker(self, worker_id: str) -> None:
+        """Remove worker presence and ownership state."""
+        with self._changed:
+            self._workers.pop(worker_id, None)
+            self._changed.notify_all()
+
+    def worker_owns_job(self, worker_id: str, job_id: str, observed_at: datetime) -> bool:
+        """Return whether a live worker is associated with the job."""
+        with self._lock:
+            worker = self._workers.get(worker_id)
+            return bool(worker is not None and worker.expires_at > observed_at and worker.active_job_id == job_id)
+
+    def get_activity(self, observed_at: datetime) -> ServerActivity:
+        """Return aggregate job states and unexpired worker leases."""
+        with self._lock:
+            states = [record.job.state for record in self._records.values()]
+            return ServerActivity(
+                queued_jobs=states.count(JobState.QUEUED),
+                running_jobs=states.count(JobState.RUNNING),
+                cancelling_jobs=states.count(JobState.CANCELLING),
+                online_workers=sum(worker.expires_at > observed_at for worker in self._workers.values()),
+            )
+
+    def update_job(
         self,
         job: Job,
         expected_revision: int,
         events: Sequence[JobEvent],
         artifact: StoredArtifact | None = None,
     ) -> Job:
-        """Save a job update only if no concurrent update has occurred.
+        """Update a job only if no concurrent update has occurred.
 
         Raises:
             JobNotFoundError: If the job does not exist.
@@ -220,6 +275,10 @@ class MemoryJobStore:
             was_queued = record.job.state == JobState.QUEUED
             updated_job = replace(job, revision=expected_revision + 1, queue_position=None)
             record.job = updated_job
+            if updated_job.state.terminal and updated_job.worker_id is not None:
+                worker = self._workers.get(updated_job.worker_id)
+                if worker is not None and worker.active_job_id == updated_job.id:
+                    worker.active_job_id = None
             if artifact is not None:
                 record.artifacts[artifact.name] = artifact
             self._append_events(record, events)
@@ -286,8 +345,8 @@ class MemoryJobStore:
                 if record.job.finished_at is not None and record.job.finished_at < cutoff
             ]
 
-    def find_claimed_before(self, cutoff: datetime) -> list[Job]:
-        """Return active jobs whose worker claim expired by the cutoff.
+    def find_jobs_without_live_workers(self, observed_at: datetime) -> list[Job]:
+        """Return active jobs without a matching unexpired worker association.
 
         Maintenance terminates them because their worker is presumed lost.
         """
@@ -296,9 +355,21 @@ class MemoryJobStore:
                 self._with_queue_position(record.job)
                 for record in self._records.values()
                 if record.job.state in {JobState.RUNNING, JobState.CANCELLING}
-                and record.job.claim_expires_at is not None
-                and record.job.claim_expires_at <= cutoff
+                and (
+                    record.job.worker_id is None
+                    or not self.worker_owns_job(record.job.worker_id, record.job.id, observed_at)
+                )
             ]
+
+    def remove_expired_worker_leases(self, observed_at: datetime) -> list[str]:
+        """Remove worker leases at or before the supplied time."""
+        with self._changed:
+            expired_ids = [worker_id for worker_id, worker in self._workers.items() if worker.expires_at <= observed_at]
+            for worker_id in expired_ids:
+                del self._workers[worker_id]
+            if expired_ids:
+                self._changed.notify_all()
+            return expired_ids
 
     def check_health(self) -> None:
         """The in-process store has no external dependency to probe."""

--- a/core/nurse_scheduling/server/stores/redis.py
+++ b/core/nurse_scheduling/server/stores/redis.py
@@ -42,6 +42,7 @@ from ..jobs.models import (
     JobState,
     OptimizationOutcome,
     OptimizationResult,
+    ServerActivity,
     StoredArtifact,
     StoreLimits,
 )
@@ -127,6 +128,10 @@ class RedisJobStore:
         """Set key (`SADD`) of non-terminal job IDs used for pending-capacity checks."""
         self._queue_key = self._key("queue")
         """Sorted-set key (`ZADD`) of queued job IDs scored by creation time for FIFO claims."""
+        self._workers_key = self._key("workers", "leases")
+        """Sorted-set key of worker IDs scored by lease expiration time."""
+        self._worker_active_jobs_key = self._key("workers", "active")
+        """Hash mapping worker IDs to their exclusively owned active job IDs."""
 
     @property
     def store_id(self) -> str:
@@ -271,11 +276,10 @@ class RedisJobStore:
         media_type = _decode(metadata.get(b"media_type")) or "application/octet-stream"
         return StoredArtifact(name=stored_name, media_type=media_type, content=content)
 
-    def claim_next(
+    def claim_next_job(
         self,
         worker_id: str,
         started_at: datetime,
-        claim_expires_at: datetime,
         runtime_identity: Mapping[str, str] | None = None,
     ) -> Job | None:
         """Atomically assign the oldest queued job to a worker.
@@ -288,7 +292,12 @@ class RedisJobStore:
         while True:
             try:
                 with self._redis.pipeline() as transaction:
-                    transaction.watch(self._queue_key)
+                    transaction.watch(self._queue_key, self._workers_key, self._worker_active_jobs_key)
+                    worker_expiry = transaction.zscore(self._workers_key, worker_id)
+                    active_job_id = _decode(transaction.hget(self._worker_active_jobs_key, worker_id))
+                    if worker_expiry is None or worker_expiry <= started_at.timestamp() or active_job_id is not None:
+                        transaction.unwatch()
+                        return None
                     queued = transaction.zrange(self._queue_key, 0, 0)
                     if not queued:
                         transaction.unwatch()
@@ -320,7 +329,6 @@ class RedisJobStore:
                         state=JobState.RUNNING,
                         started_at=started_at,
                         worker_id=worker_id,
-                        claim_expires_at=claim_expires_at,
                         revision=current.revision + 1,
                         queue_position=None,
                     )
@@ -340,6 +348,7 @@ class RedisJobStore:
                     transaction.multi()
                     transaction.set(job_key, self._serialize_job(claimed))
                     transaction.zrem(self._queue_key, job_id)
+                    transaction.hset(self._worker_active_jobs_key, worker_id, job_id)
                     self._stage_event_appends(transaction, job_id, [event])
                     self._stage_queue_position_events(transaction, remaining_ids, started_at)
                     transaction.execute()
@@ -347,14 +356,82 @@ class RedisJobStore:
             except redis.WatchError:
                 continue
 
-    def save(
+    def register_worker(self, worker_id: str, registered_at: datetime, lease_expires_at: datetime) -> bool:
+        """Register an idle worker without overwriting live or unresolved ownership."""
+        while True:
+            try:
+                with self._redis.pipeline() as transaction:
+                    transaction.watch(self._workers_key, self._worker_active_jobs_key)
+                    current_expiry = transaction.zscore(self._workers_key, worker_id)
+                    active_job_id = transaction.hget(self._worker_active_jobs_key, worker_id)
+                    if (
+                        current_expiry is not None and current_expiry > registered_at.timestamp()
+                    ) or active_job_id is not None:
+                        transaction.unwatch()
+                        return False
+                    transaction.multi()
+                    transaction.zadd(self._workers_key, {worker_id: lease_expires_at.timestamp()})
+                    transaction.hdel(self._worker_active_jobs_key, worker_id)
+                    transaction.execute()
+                    return True
+            except redis.WatchError:
+                continue
+
+    def renew_worker(self, worker_id: str, renewed_at: datetime, lease_expires_at: datetime) -> bool:
+        """Renew a worker lease only while its current lease is unexpired."""
+        while True:
+            try:
+                with self._redis.pipeline() as transaction:
+                    transaction.watch(self._workers_key)
+                    current_expiry = transaction.zscore(self._workers_key, worker_id)
+                    if current_expiry is None or current_expiry <= renewed_at.timestamp():
+                        transaction.unwatch()
+                        return False
+                    transaction.multi()
+                    transaction.zadd(self._workers_key, {worker_id: lease_expires_at.timestamp()})
+                    transaction.execute()
+                    return True
+            except redis.WatchError:
+                continue
+
+    def unregister_worker(self, worker_id: str) -> None:
+        """Remove worker presence and its active-job association."""
+        with self._redis.pipeline() as transaction:
+            transaction.zrem(self._workers_key, worker_id)
+            transaction.hdel(self._worker_active_jobs_key, worker_id)
+            transaction.execute()
+
+    def worker_owns_job(self, worker_id: str, job_id: str, observed_at: datetime) -> bool:
+        """Return whether a live worker lease points to the supplied job."""
+        with self._redis.pipeline() as transaction:
+            transaction.zscore(self._workers_key, worker_id)
+            transaction.hget(self._worker_active_jobs_key, worker_id)
+            current_expiry, active_job_id = transaction.execute()
+        return bool(
+            current_expiry is not None and current_expiry > observed_at.timestamp() and _decode(active_job_id) == job_id
+        )
+
+    def get_activity(self, observed_at: datetime) -> ServerActivity:
+        """Return aggregate current job states and unexpired worker leases."""
+        raw_ids = self._redis.smembers(self._pending_key)
+        raw_jobs = self._redis.mget([self._job_key(_decode(raw_id)) for raw_id in raw_ids]) if raw_ids else []
+        states = [self._deserialize_job(raw).state for raw in raw_jobs if raw is not None]
+        online_workers = self._redis.zcount(self._workers_key, f"({observed_at.timestamp()}", "+inf")
+        return ServerActivity(
+            queued_jobs=states.count(JobState.QUEUED),
+            running_jobs=states.count(JobState.RUNNING),
+            cancelling_jobs=states.count(JobState.CANCELLING),
+            online_workers=online_workers,
+        )
+
+    def update_job(
         self,
         job: Job,
         expected_revision: int,
         events: Sequence[JobEvent],
         artifact: StoredArtifact | None = None,
     ) -> Job:
-        """Save a job update only if no concurrent update has occurred.
+        """Update a job only if no concurrent update has occurred.
 
         Raises:
             JobNotFoundError: If the job does not exist.
@@ -383,12 +460,20 @@ class RedisJobStore:
                             for raw_id in transaction.zrange(self._queue_key, 0, -1)
                             if (queued_id := _decode(raw_id)) != updated_job.id
                         ]
+                    worker_id_to_release: str | None = None
+                    if updated_job.state.terminal and updated_job.worker_id is not None:
+                        transaction.watch(self._worker_active_jobs_key)
+                        active_job_id = _decode(transaction.hget(self._worker_active_jobs_key, updated_job.worker_id))
+                        if active_job_id == updated_job.id:
+                            worker_id_to_release = updated_job.worker_id
                     transaction.multi()
                     transaction.set(job_key, self._serialize_job(updated_job))
                     if updated_job.state != JobState.QUEUED:
                         transaction.zrem(self._queue_key, updated_job.id)
                     if updated_job.state.terminal:
                         transaction.srem(self._pending_key, updated_job.id)
+                    if worker_id_to_release is not None:
+                        transaction.hdel(self._worker_active_jobs_key, worker_id_to_release)
                     if artifact is not None:
                         transaction.set(self._artifact_key(updated_job.id), artifact.content)
                         transaction.hset(
@@ -458,8 +543,8 @@ class RedisJobStore:
         """
         return [job for job in self._all_jobs() if job.finished_at is not None and job.finished_at < cutoff]
 
-    def find_claimed_before(self, cutoff: datetime) -> list[Job]:
-        """Return active jobs whose worker claim expired by the cutoff.
+    def find_jobs_without_live_workers(self, observed_at: datetime) -> list[Job]:
+        """Return active jobs without a matching live worker association.
 
         Maintenance terminates them because their worker is presumed lost.
 
@@ -470,9 +555,31 @@ class RedisJobStore:
             job
             for job in self._all_jobs()
             if job.state in {JobState.RUNNING, JobState.CANCELLING}
-            and job.claim_expires_at is not None
-            and job.claim_expires_at <= cutoff
+            and (job.worker_id is None or not self.worker_owns_job(job.worker_id, job.id, observed_at))
         ]
+
+    def remove_expired_worker_leases(self, observed_at: datetime) -> list[str]:
+        """Atomically remove worker leases that cannot be renewed anymore."""
+        while True:
+            try:
+                with self._redis.pipeline() as transaction:
+                    transaction.watch(self._workers_key, self._worker_active_jobs_key)
+                    raw_ids = transaction.zrangebyscore(
+                        self._workers_key,
+                        "-inf",
+                        observed_at.timestamp(),
+                    )
+                    worker_ids = [_decode(raw_id) for raw_id in raw_ids]
+                    if not worker_ids:
+                        transaction.unwatch()
+                        return []
+                    transaction.multi()
+                    transaction.zrem(self._workers_key, *worker_ids)
+                    transaction.hdel(self._worker_active_jobs_key, *worker_ids)
+                    transaction.execute()
+                    return worker_ids
+            except redis.WatchError:
+                continue
 
     def check_health(self) -> None:
         """Raise an error when Redis is unavailable or its identity changed.
@@ -583,7 +690,6 @@ class RedisJobStore:
             "started_at": job.started_at.isoformat() if job.started_at is not None else None,
             "finished_at": job.finished_at.isoformat() if job.finished_at is not None else None,
             "worker_id": job.worker_id,
-            "claim_expires_at": job.claim_expires_at.isoformat() if job.claim_expires_at is not None else None,
             "result": (
                 {
                     "outcome": job.result.outcome.value,
@@ -625,9 +731,6 @@ class RedisJobStore:
             started_at=datetime.fromisoformat(data["started_at"]) if data.get("started_at") else None,
             finished_at=datetime.fromisoformat(data["finished_at"]) if data.get("finished_at") else None,
             worker_id=data.get("worker_id"),
-            claim_expires_at=(
-                datetime.fromisoformat(data["claim_expires_at"]) if data.get("claim_expires_at") else None
-            ),
             result=(
                 OptimizationResult(
                     outcome=OptimizationOutcome(result["outcome"]),

--- a/core/nurse_scheduling/server/stores/redis.py
+++ b/core/nurse_scheduling/server/stores/redis.py
@@ -45,6 +45,7 @@ from ..jobs.models import (
     ServerActivity,
     StoredArtifact,
     StoreLimits,
+    WorkerLease,
 )
 from ..retry import retry_with_backoff
 
@@ -130,6 +131,8 @@ class RedisJobStore:
         """Sorted-set key (`ZADD`) of queued job IDs scored by creation time for FIFO claims."""
         self._workers_key = self._key("workers", "leases")
         """Sorted-set key of worker IDs scored by lease expiration time."""
+        self._worker_tokens_key = self._key("workers", "tokens")
+        """Hash mapping worker IDs to their current opaque lease tokens."""
         self._worker_active_jobs_key = self._key("workers", "active")
         """Hash mapping worker IDs to their exclusively owned active job IDs."""
 
@@ -278,7 +281,7 @@ class RedisJobStore:
 
     def claim_next_job(
         self,
-        worker_id: str,
+        lease: WorkerLease,
         started_at: datetime,
         runtime_identity: Mapping[str, str] | None = None,
     ) -> Job | None:
@@ -292,10 +295,21 @@ class RedisJobStore:
         while True:
             try:
                 with self._redis.pipeline() as transaction:
-                    transaction.watch(self._queue_key, self._workers_key, self._worker_active_jobs_key)
-                    worker_expiry = transaction.zscore(self._workers_key, worker_id)
-                    active_job_id = _decode(transaction.hget(self._worker_active_jobs_key, worker_id))
-                    if worker_expiry is None or worker_expiry <= started_at.timestamp() or active_job_id is not None:
+                    transaction.watch(
+                        self._queue_key,
+                        self._workers_key,
+                        self._worker_tokens_key,
+                        self._worker_active_jobs_key,
+                    )
+                    worker_expiry = transaction.zscore(self._workers_key, lease.worker_id)
+                    worker_token = _decode(transaction.hget(self._worker_tokens_key, lease.worker_id))
+                    active_job_id = _decode(transaction.hget(self._worker_active_jobs_key, lease.worker_id))
+                    if (
+                        worker_expiry is None
+                        or worker_expiry <= started_at.timestamp()
+                        or worker_token != lease.token
+                        or active_job_id is not None
+                    ):
                         transaction.unwatch()
                         return None
                     queued = transaction.zrange(self._queue_key, 0, 0)
@@ -328,7 +342,7 @@ class RedisJobStore:
                         current,
                         state=JobState.RUNNING,
                         started_at=started_at,
-                        worker_id=worker_id,
+                        worker_id=lease.worker_id,
                         revision=current.revision + 1,
                         queue_position=None,
                     )
@@ -339,7 +353,7 @@ class RedisJobStore:
                             "queue_position": None,
                             "cancel_requested": False,
                             "early_completion_requested": False,
-                            "worker_id": worker_id,
+                            "worker_id": lease.worker_id,
                             **({"runtime": dict(runtime_identity)} if runtime_identity is not None else {}),
                         },
                         occurred_at=started_at,
@@ -348,7 +362,7 @@ class RedisJobStore:
                     transaction.multi()
                     transaction.set(job_key, self._serialize_job(claimed))
                     transaction.zrem(self._queue_key, job_id)
-                    transaction.hset(self._worker_active_jobs_key, worker_id, job_id)
+                    transaction.hset(self._worker_active_jobs_key, lease.worker_id, job_id)
                     self._stage_event_appends(transaction, job_id, [event])
                     self._stage_queue_position_events(transaction, remaining_ids, started_at)
                     transaction.execute()
@@ -356,50 +370,68 @@ class RedisJobStore:
             except redis.WatchError:
                 continue
 
-    def register_worker(self, worker_id: str, registered_at: datetime, lease_expires_at: datetime) -> bool:
+    def register_worker(self, lease: WorkerLease, registered_at: datetime) -> bool:
         """Register an idle worker without overwriting live or unresolved ownership."""
         while True:
             try:
                 with self._redis.pipeline() as transaction:
-                    transaction.watch(self._workers_key, self._worker_active_jobs_key)
-                    current_expiry = transaction.zscore(self._workers_key, worker_id)
-                    active_job_id = transaction.hget(self._worker_active_jobs_key, worker_id)
+                    transaction.watch(self._workers_key, self._worker_tokens_key, self._worker_active_jobs_key)
+                    current_expiry = transaction.zscore(self._workers_key, lease.worker_id)
+                    active_job_id = transaction.hget(self._worker_active_jobs_key, lease.worker_id)
                     if (
                         current_expiry is not None and current_expiry > registered_at.timestamp()
                     ) or active_job_id is not None:
                         transaction.unwatch()
                         return False
                     transaction.multi()
-                    transaction.zadd(self._workers_key, {worker_id: lease_expires_at.timestamp()})
-                    transaction.hdel(self._worker_active_jobs_key, worker_id)
+                    transaction.zadd(self._workers_key, {lease.worker_id: lease.expires_at.timestamp()})
+                    transaction.hset(self._worker_tokens_key, lease.worker_id, lease.token)
+                    transaction.hdel(self._worker_active_jobs_key, lease.worker_id)
                     transaction.execute()
                     return True
             except redis.WatchError:
                 continue
 
-    def renew_worker(self, worker_id: str, renewed_at: datetime, lease_expires_at: datetime) -> bool:
+    def renew_worker(self, lease: WorkerLease, renewed_at: datetime, lease_expires_at: datetime) -> bool:
         """Renew a worker lease only while its current lease is unexpired."""
         while True:
             try:
                 with self._redis.pipeline() as transaction:
-                    transaction.watch(self._workers_key)
-                    current_expiry = transaction.zscore(self._workers_key, worker_id)
-                    if current_expiry is None or current_expiry <= renewed_at.timestamp():
+                    transaction.watch(self._workers_key, self._worker_tokens_key)
+                    current_expiry = transaction.zscore(self._workers_key, lease.worker_id)
+                    current_token = _decode(transaction.hget(self._worker_tokens_key, lease.worker_id))
+                    if (
+                        current_expiry is None
+                        or current_expiry <= renewed_at.timestamp()
+                        or current_token != lease.token
+                    ):
                         transaction.unwatch()
                         return False
                     transaction.multi()
-                    transaction.zadd(self._workers_key, {worker_id: lease_expires_at.timestamp()})
+                    transaction.zadd(self._workers_key, {lease.worker_id: lease_expires_at.timestamp()})
                     transaction.execute()
                     return True
             except redis.WatchError:
                 continue
 
-    def unregister_worker(self, worker_id: str) -> None:
-        """Remove worker presence and its active-job association."""
-        with self._redis.pipeline() as transaction:
-            transaction.zrem(self._workers_key, worker_id)
-            transaction.hdel(self._worker_active_jobs_key, worker_id)
-            transaction.execute()
+    def unregister_worker(self, lease: WorkerLease) -> None:
+        """Remove matching worker presence and its active-job association."""
+        while True:
+            try:
+                with self._redis.pipeline() as transaction:
+                    transaction.watch(self._worker_tokens_key)
+                    current_token = _decode(transaction.hget(self._worker_tokens_key, lease.worker_id))
+                    if current_token != lease.token:
+                        transaction.unwatch()
+                        return
+                    transaction.multi()
+                    transaction.zrem(self._workers_key, lease.worker_id)
+                    transaction.hdel(self._worker_tokens_key, lease.worker_id)
+                    transaction.hdel(self._worker_active_jobs_key, lease.worker_id)
+                    transaction.execute()
+                    return
+            except redis.WatchError:
+                continue
 
     def worker_owns_job(self, worker_id: str, job_id: str, observed_at: datetime) -> bool:
         """Return whether a live worker lease points to the supplied job."""
@@ -409,6 +441,20 @@ class RedisJobStore:
             current_expiry, active_job_id = transaction.execute()
         return bool(
             current_expiry is not None and current_expiry > observed_at.timestamp() and _decode(active_job_id) == job_id
+        )
+
+    def lease_owns_job(self, lease: WorkerLease, job_id: str, observed_at: datetime) -> bool:
+        """Return whether this exact live lease points to the supplied job."""
+        with self._redis.pipeline() as transaction:
+            transaction.zscore(self._workers_key, lease.worker_id)
+            transaction.hget(self._worker_tokens_key, lease.worker_id)
+            transaction.hget(self._worker_active_jobs_key, lease.worker_id)
+            current_expiry, current_token, active_job_id = transaction.execute()
+        return bool(
+            current_expiry is not None
+            and current_expiry > observed_at.timestamp()
+            and _decode(current_token) == lease.token
+            and _decode(active_job_id) == job_id
         )
 
     def get_activity(self, observed_at: datetime) -> ServerActivity:
@@ -430,8 +476,15 @@ class RedisJobStore:
         expected_revision: int,
         events: Sequence[JobEvent],
         artifact: StoredArtifact | None = None,
+        *,
+        worker_lease: WorkerLease | None = None,
+        worker_lease_observed_at: datetime | None = None,
     ) -> Job:
-        """Update a job only if no concurrent update has occurred.
+        """Update a job if its revision and optional worker lease still match.
+
+        Omit `worker_lease` only for server-authorized API or maintenance
+        transitions. Worker-originated updates must include the lease and its
+        observation time.
 
         Raises:
             JobNotFoundError: If the job does not exist.
@@ -442,7 +495,10 @@ class RedisJobStore:
         while True:
             try:
                 with self._redis.pipeline() as transaction:
-                    transaction.watch(job_key)
+                    watched_keys = [job_key]
+                    if worker_lease is not None:
+                        watched_keys.extend([self._workers_key, self._worker_tokens_key, self._worker_active_jobs_key])
+                    transaction.watch(*watched_keys)
                     raw = transaction.get(job_key)
                     if raw is None:
                         transaction.unwatch()
@@ -451,6 +507,22 @@ class RedisJobStore:
                     if current.revision != expected_revision:
                         transaction.unwatch()
                         raise StoreWriteConflictError(f"Job revision changed: {job.id}")
+                    if worker_lease is not None:
+                        if worker_lease_observed_at is None:
+                            transaction.unwatch()
+                            raise ValueError("worker_lease_observed_at is required with a worker lease")
+                        worker_expiry = transaction.zscore(self._workers_key, worker_lease.worker_id)
+                        worker_token = _decode(transaction.hget(self._worker_tokens_key, worker_lease.worker_id))
+                        active_job_id = _decode(transaction.hget(self._worker_active_jobs_key, worker_lease.worker_id))
+                        if (
+                            current.worker_id != worker_lease.worker_id
+                            or worker_expiry is None
+                            or worker_expiry <= worker_lease_observed_at.timestamp()
+                            or worker_token != worker_lease.token
+                            or active_job_id != job.id
+                        ):
+                            transaction.unwatch()
+                            return self.get(job.id)
                     updated_job = replace(job, revision=expected_revision + 1, queue_position=None)
                     remaining_queue_ids: list[str] = []
                     if current.state == JobState.QUEUED and updated_job.state != JobState.QUEUED:
@@ -563,7 +635,7 @@ class RedisJobStore:
         while True:
             try:
                 with self._redis.pipeline() as transaction:
-                    transaction.watch(self._workers_key, self._worker_active_jobs_key)
+                    transaction.watch(self._workers_key, self._worker_tokens_key, self._worker_active_jobs_key)
                     raw_ids = transaction.zrangebyscore(
                         self._workers_key,
                         "-inf",
@@ -575,6 +647,7 @@ class RedisJobStore:
                         return []
                     transaction.multi()
                     transaction.zrem(self._workers_key, *worker_ids)
+                    transaction.hdel(self._worker_tokens_key, *worker_ids)
                     transaction.hdel(self._worker_active_jobs_key, *worker_ids)
                     transaction.execute()
                     return worker_ids

--- a/core/nurse_scheduling/server/stores/redis.py
+++ b/core/nurse_scheduling/server/stores/redis.py
@@ -279,6 +279,18 @@ class RedisJobStore:
         media_type = _decode(metadata.get(b"media_type")) or "application/octet-stream"
         return StoredArtifact(name=stored_name, media_type=media_type, content=content)
 
+    @staticmethod
+    def _lease_is_live(
+        lease: WorkerLease,
+        observed_at: datetime,
+        stored_expiry: float | None,
+        stored_token: str | None,
+    ) -> bool:
+        """Return whether stored values describe this exact live lease."""
+        return bool(
+            stored_expiry is not None and stored_expiry > observed_at.timestamp() and stored_token == lease.token
+        )
+
     def claim_next_job(
         self,
         lease: WorkerLease,
@@ -305,9 +317,7 @@ class RedisJobStore:
                     worker_token = _decode(transaction.hget(self._worker_tokens_key, lease.worker_id))
                     active_job_id = _decode(transaction.hget(self._worker_active_jobs_key, lease.worker_id))
                     if (
-                        worker_expiry is None
-                        or worker_expiry <= started_at.timestamp()
-                        or worker_token != lease.token
+                        not self._lease_is_live(lease, started_at, worker_expiry, worker_token)
                         or active_job_id is not None
                     ):
                         transaction.unwatch()
@@ -400,11 +410,7 @@ class RedisJobStore:
                     transaction.watch(self._workers_key, self._worker_tokens_key)
                     current_expiry = transaction.zscore(self._workers_key, lease.worker_id)
                     current_token = _decode(transaction.hget(self._worker_tokens_key, lease.worker_id))
-                    if (
-                        current_expiry is None
-                        or current_expiry <= renewed_at.timestamp()
-                        or current_token != lease.token
-                    ):
+                    if not self._lease_is_live(lease, renewed_at, current_expiry, current_token):
                         transaction.unwatch()
                         return False
                     transaction.multi()
@@ -433,7 +439,7 @@ class RedisJobStore:
             except redis.WatchError:
                 continue
 
-    def worker_owns_job(self, worker_id: str, job_id: str, observed_at: datetime) -> bool:
+    def live_worker_owns_job(self, worker_id: str, job_id: str, observed_at: datetime) -> bool:
         """Return whether a live worker lease points to the supplied job."""
         with self._redis.pipeline() as transaction:
             transaction.zscore(self._workers_key, worker_id)
@@ -450,10 +456,8 @@ class RedisJobStore:
             transaction.hget(self._worker_tokens_key, lease.worker_id)
             transaction.hget(self._worker_active_jobs_key, lease.worker_id)
             current_expiry, current_token, active_job_id = transaction.execute()
-        return bool(
-            current_expiry is not None
-            and current_expiry > observed_at.timestamp()
-            and _decode(current_token) == lease.token
+        return (
+            self._lease_is_live(lease, observed_at, current_expiry, _decode(current_token))
             and _decode(active_job_id) == job_id
         )
 
@@ -516,9 +520,12 @@ class RedisJobStore:
                         active_job_id = _decode(transaction.hget(self._worker_active_jobs_key, worker_lease.worker_id))
                         if (
                             current.worker_id != worker_lease.worker_id
-                            or worker_expiry is None
-                            or worker_expiry <= worker_lease_observed_at.timestamp()
-                            or worker_token != worker_lease.token
+                            or not self._lease_is_live(
+                                worker_lease,
+                                worker_lease_observed_at,
+                                worker_expiry,
+                                worker_token,
+                            )
                             or active_job_id != job.id
                         ):
                             transaction.unwatch()
@@ -627,7 +634,7 @@ class RedisJobStore:
             job
             for job in self._all_jobs()
             if job.state in {JobState.RUNNING, JobState.CANCELLING}
-            and (job.worker_id is None or not self.worker_owns_job(job.worker_id, job.id, observed_at))
+            and (job.worker_id is None or not self.live_worker_owns_job(job.worker_id, job.id, observed_at))
         ]
 
     def remove_expired_worker_leases(self, observed_at: datetime) -> list[str]:

--- a/core/tests/test_optimize_job_backends.py
+++ b/core/tests/test_optimize_job_backends.py
@@ -131,7 +131,7 @@ def _controller(store, *, max_pending=8, max_retained=32, now=None, runtime_iden
         store,
         limits=StoreLimits(max_pending=max_pending, max_retained=max_retained),
         retention_seconds=60,
-        claim_lease_seconds=30,
+        worker_lease_seconds=30,
         runtime_identity=runtime_identity,
         clock=clock,
         id_factory=lambda: next(sequence),
@@ -147,6 +147,11 @@ def _create(controller, input_name="input.yaml"):
         timeout_seconds=60,
         input_bytes=b"apiVersion: alpha\n",
     )
+
+
+def _claim(controller, worker_id="worker"):
+    assert controller.register_worker(worker_id)
+    return controller.claim_next_job(worker_id)
 
 
 def _raise_watch_error_once(store, monkeypatch) -> None:
@@ -228,6 +233,17 @@ def test_redis_store_identity_is_shared_by_one_namespace(fake_redis_store_factor
 
     assert len({store.store_id for store in shared}) == 1
     assert shared[0].store_id != separate.store_id
+
+
+def test_redis_activity_is_shared_by_one_namespace(fake_redis_store_factory):
+    prefix = f"nurse_scheduling:test:activity:{uuid.uuid4().hex}"
+    first = _controller(fake_redis_store_factory(key_prefix=prefix))
+    second = _controller(fake_redis_store_factory(key_prefix=prefix))
+
+    assert first.register_worker("worker-1")
+    assert second.get_activity().online_workers == 1
+    assert second.register_worker("worker-2")
+    assert first.get_activity().online_workers == 2
 
 
 def test_redis_store_health_rejects_identity_change(fake_redis_store_factory):
@@ -316,7 +332,7 @@ def test_store_round_trips_lifecycle_input_events_and_artifact(store):
     assert created.queue_position == 1
     assert controller.get_input(created.id) == b"apiVersion: alpha\n"
 
-    claimed = controller.claim_next_job("worker")
+    claimed = _claim(controller)
     assert claimed is not None
     assert claimed.state == JobState.RUNNING
     assert claimed.worker_id == "worker"
@@ -362,7 +378,7 @@ def test_store_reports_missing_input_and_artifacts(store):
     with pytest.raises(JobInputNotFoundError):
         controller.get_input(created.id)
 
-    claimed = controller.claim_next_job("worker")
+    claimed = _claim(controller)
     assert claimed is not None
     artifact = StoredArtifact("input.xlsx", "application/test", b"xlsx")
     controller.complete_job(
@@ -381,9 +397,10 @@ def test_store_reports_missing_input_and_artifacts(store):
 def test_store_handles_empty_queries_and_missing_jobs(store):
     now = datetime.now(timezone.utc)
 
-    assert store.claim_next("worker", now, now + timedelta(seconds=30)) is None
+    assert store.register_worker("worker", now, now + timedelta(seconds=30))
+    assert store.claim_next_job("worker", now) is None
     assert store.find_finished_before(now) == []
-    assert store.find_claimed_before(now) == []
+    assert store.find_jobs_without_live_workers(now) == []
     store.check_health()
 
     with pytest.raises(JobNotFoundError):
@@ -414,7 +431,7 @@ def test_store_rejects_duplicate_ids_and_prunes_terminal_jobs(store):
         controller.get_job(first.id)
 
 
-def test_store_rejects_stale_delete_and_missing_save(store):
+def test_store_rejects_stale_delete_and_missing_update(store):
     controller = _controller(store)
     created = _create(controller)
 
@@ -422,17 +439,17 @@ def test_store_rejects_stale_delete_and_missing_save(store):
         store.delete(created.id, created.revision + 1)
     store.delete(created.id, created.revision)
     with pytest.raises(JobNotFoundError):
-        store.save(created, created.revision, [])
+        store.update_job(created, created.revision, [])
 
 
-def test_store_reorders_queue_when_saved_without_events(store):
+def test_store_reorders_queue_when_updated_without_events(store):
     now = datetime.now(timezone.utc)
     controller = _controller(store, now=now)
     first = _create(controller, "first.yaml")
     second = _create(controller, "second.yaml")
 
     cancelled = replace(first, state=JobState.CANCELLED, finished_at=now)
-    saved = store.save(cancelled, first.revision, [])
+    saved = store.update_job(cancelled, first.revision, [])
 
     assert saved.state == JobState.CANCELLED
     events = store.stream_events(second.id, after_id=None, keepalive_seconds=0.01)
@@ -466,7 +483,7 @@ def test_redis_store_uses_artifact_metadata_defaults(fake_redis_store_factory):
     store = fake_redis_store_factory()
     controller = _controller(store)
     created = _create(controller)
-    claimed = controller.claim_next_job("worker")
+    claimed = _claim(controller)
     assert claimed is not None
     artifact = StoredArtifact("input.xlsx", "application/test", b"xlsx")
     controller.complete_job(
@@ -487,16 +504,17 @@ def test_redis_store_uses_artifact_metadata_defaults(fake_redis_store_factory):
 def test_redis_store_removes_corrupt_queue_entries(fake_redis_store_factory):
     store = fake_redis_store_factory()
     now = datetime.now(timezone.utc)
+    assert store.register_worker("worker", now, now + timedelta(seconds=30))
     store._redis.zadd(store._queue_key, {"orphan": now.timestamp()})
 
-    assert store.claim_next("worker", now, now + timedelta(seconds=30)) is None
+    assert store.claim_next_job("worker", now) is None
 
     controller = _controller(store, now=now)
     created = _create(controller)
     controller.cancel_job(created.id)
     store._redis.zadd(store._queue_key, {created.id: now.timestamp()})
 
-    assert store.claim_next("worker", now, now + timedelta(seconds=30)) is None
+    assert store.claim_next_job("worker", now) is None
 
 
 def test_redis_event_stream_treats_socket_timeout_as_keepalive(fake_redis_store_factory, monkeypatch):
@@ -512,7 +530,7 @@ def test_redis_event_stream_treats_socket_timeout_as_keepalive(fake_redis_store_
     assert next(resumed) is None
 
 
-@pytest.mark.parametrize("operation", ["create", "claim", "save", "delete"])
+@pytest.mark.parametrize("operation", ["create", "register", "renew", "claim", "update", "delete"])
 def test_redis_store_retries_watch_errors(fake_redis_store_factory, monkeypatch, operation):
     store = fake_redis_store_factory()
     controller = _controller(store)
@@ -522,14 +540,27 @@ def test_redis_store_retries_watch_errors(fake_redis_store_factory, monkeypatch,
         assert _create(controller).state == JobState.QUEUED
         return
 
+    if operation == "register":
+        _raise_watch_error_once(store, monkeypatch)
+        assert controller.register_worker("worker")
+        return
+
+    if operation == "renew":
+        assert controller.register_worker("worker")
+        _raise_watch_error_once(store, monkeypatch)
+        assert controller.renew_worker("worker")
+        return
+
     created = _create(controller)
     if operation == "delete":
         created = controller.cancel_job(created.id)
+    if operation == "claim":
+        assert controller.register_worker("worker")
     _raise_watch_error_once(store, monkeypatch)
 
     if operation == "claim":
         assert controller.claim_next_job("worker").state == JobState.RUNNING
-    elif operation == "save":
+    elif operation == "update":
         assert controller.cancel_job(created.id).state == JobState.CANCELLED
     else:
         controller.delete_job(created.id)
@@ -540,7 +571,7 @@ def test_redis_store_retries_watch_errors(fake_redis_store_factory, monkeypatch,
 def test_store_rejects_events_from_stale_workers_and_terminal_jobs(store):
     controller = _controller(store)
     created = _create(controller)
-    claimed = controller.claim_next_job("worker")
+    claimed = _claim(controller)
     assert claimed is not None
 
     accepted = controller.record_score_and_event(
@@ -586,7 +617,7 @@ def test_store_queue_positions_are_derived_from_queue_order(store):
     assert controller.get_job(first.id).queue_position == 1
     assert controller.get_job(second.id).queue_position == 2
 
-    controller.claim_next_job("worker")
+    _claim(controller)
     assert controller.get_job(second.id).queue_position == 1
 
 
@@ -619,7 +650,7 @@ def test_controller_cancellation_policy_is_shared_by_stores(store):
     assert cancelled.state == JobState.CANCELLED
 
     running = _create(controller, "running.yaml")
-    controller.claim_next_job("worker")
+    _claim(controller)
     cancelling = controller.cancel_job(running.id)
     assert cancelling.state == JobState.CANCELLING
     stale = controller.complete_cancellation(running.id, "other-worker")
@@ -641,7 +672,7 @@ def test_store_enforces_capacity_across_concurrent_creates(store):
         store,
         limits=StoreLimits(max_pending=4, max_retained=4),
         retention_seconds=60,
-        claim_lease_seconds=30,
+        worker_lease_seconds=30,
     )
 
     def create(index: int):
@@ -668,11 +699,93 @@ def test_store_claims_each_job_at_most_once_under_concurrency(store):
     created_ids = {_create(controller, f"{index}.yaml").id for index in range(6)}
 
     with ThreadPoolExecutor(max_workers=6) as executor:
-        claimed = list(executor.map(lambda index: controller.claim_next_job(f"worker-{index}"), range(6)))
+        claimed = list(executor.map(lambda index: _claim(controller, f"worker-{index}"), range(6)))
 
     claimed_ids = {job.id for job in claimed if job is not None}
     assert claimed_ids == created_ids
     assert len(claimed_ids) == len(claimed)
+
+
+def test_store_reports_job_and_worker_activity_across_lifecycle(store):
+    now = datetime.now(timezone.utc)
+    controller = _controller(store, now=now)
+    first = _create(controller, "first.yaml")
+    _create(controller, "second.yaml")
+    _create(controller, "third.yaml")
+
+    first_running = _claim(controller, "worker-1")
+    second_running = _claim(controller, "worker-2")
+    assert first_running is not None
+    assert second_running is not None
+    controller.cancel_job(first.id)
+
+    activity = controller.get_activity()
+    assert activity.queued_jobs == 1
+    assert activity.running_jobs == 1
+    assert activity.cancelling_jobs == 1
+    assert activity.online_workers == 2
+
+    controller.complete_cancellation(first.id, "worker-1")
+    third_running = controller.claim_next_job("worker-1")
+    assert third_running is not None
+    activity = controller.get_activity()
+    assert activity.queued_jobs == 0
+    assert activity.running_jobs == 2
+    assert activity.cancelling_jobs == 0
+    assert activity.online_workers == 2
+
+
+def test_expired_worker_lease_cannot_be_renewed_and_can_be_replaced(store):
+    now = [datetime.now(timezone.utc)]
+    controller = JobController(
+        store,
+        limits=StoreLimits(max_pending=2, max_retained=4),
+        retention_seconds=60,
+        worker_lease_seconds=10,
+        clock=lambda: now[0],
+    )
+
+    assert controller.register_worker("worker") == now[0] + timedelta(seconds=10)
+    now[0] += timedelta(seconds=10)
+    assert controller.renew_worker("worker") is None
+    assert controller.get_activity().online_workers == 0
+    assert store.remove_expired_worker_leases(now[0]) == ["worker"]
+    assert controller.register_worker("worker") == now[0] + timedelta(seconds=10)
+    assert controller.get_activity().online_workers == 1
+
+
+def test_expired_worker_lease_rejects_late_terminal_outcomes(store):
+    now = [datetime.now(timezone.utc)]
+    controller = JobController(
+        store,
+        limits=StoreLimits(max_pending=1, max_retained=2),
+        retention_seconds=60,
+        worker_lease_seconds=10,
+        clock=lambda: now[0],
+    )
+    created = _create(controller)
+    claimed = _claim(controller)
+    assert claimed is not None
+    now[0] += timedelta(seconds=11)
+
+    artifact = StoredArtifact("late.xlsx", "application/test", b"late")
+    after_completion = controller.complete_job(
+        created.id,
+        OptimizationResult(OptimizationOutcome.OPTIMAL, 42, "OPTIMAL", "optimality_proven"),
+        artifact,
+    )
+    after_failure = controller.fail_job(created.id, JobFailure("late_failure", "late"))
+
+    assert after_completion.state == JobState.RUNNING
+    assert after_failure.state == JobState.RUNNING
+    assert after_failure.revision == claimed.revision
+    cancelling = controller.cancel_job(created.id)
+    after_cancellation = controller.complete_cancellation(created.id, "worker")
+    assert cancelling.state == JobState.CANCELLING
+    assert after_cancellation.state == JobState.CANCELLING
+    assert after_cancellation.revision == cancelling.revision
+    with pytest.raises(JobArtifactNotFoundError):
+        store.get_artifact(created.id, artifact.name)
 
 
 def test_revision_prevents_late_overwrite(store):
@@ -682,7 +795,7 @@ def test_revision_prevents_late_overwrite(store):
     controller.cancel_job(created.id)
 
     with pytest.raises(StoreWriteConflictError):
-        store.save(stale, stale.revision, [])
+        store.update_job(stale, stale.revision, [])
 
 
 def test_controller_retries_internal_store_conflict_during_delete():
@@ -745,7 +858,7 @@ def test_retention_cleanup_removes_old_terminal_jobs(store):
         store,
         limits=StoreLimits(max_pending=8, max_retained=32),
         retention_seconds=60,
-        claim_lease_seconds=30,
+        worker_lease_seconds=30,
         clock=lambda: now + timedelta(seconds=61),
     )
     assert later.expire_jobs() == [created.id]
@@ -757,11 +870,11 @@ def test_completed_job_can_resume_after_client_sleeps(store):
         store,
         limits=StoreLimits(max_pending=8, max_retained=DEFAULT_MAX_RETAINED_JOBS),
         retention_seconds=DEFAULT_JOB_RETENTION_SECONDS,
-        claim_lease_seconds=30,
+        worker_lease_seconds=30,
         clock=lambda: now,
     )
     created = _create(controller)
-    running = controller.claim_next_job("worker")
+    running = _claim(controller)
     assert running is not None
 
     event_stream = controller.stream_events(running.id, after_id=None, keepalive_seconds=0.01)
@@ -782,7 +895,7 @@ def test_completed_job_can_resume_after_client_sleeps(store):
         store,
         limits=StoreLimits(max_pending=8, max_retained=DEFAULT_MAX_RETAINED_JOBS),
         retention_seconds=DEFAULT_JOB_RETENTION_SECONDS,
-        claim_lease_seconds=30,
+        worker_lease_seconds=30,
         clock=lambda: now + timedelta(hours=23),
     )
     assert after_sleep.expire_jobs() == []
@@ -825,7 +938,7 @@ def test_queue_position_events_track_queue_reordering(store):
     first = _create(controller, "first.yaml")
     second = _create(controller, "second.yaml")
 
-    controller.claim_next_job("worker")
+    _claim(controller)
 
     events = controller.stream_events(second.id, after_id=None, keepalive_seconds=0.01)
     queued = [next(events), next(events)]
@@ -833,28 +946,28 @@ def test_queue_position_events_track_queue_reordering(store):
     assert controller.get_job(first.id).state == JobState.RUNNING
 
 
-def test_expired_worker_claim_fails_job_and_releases_capacity(store):
+def test_expired_worker_lease_fails_job_and_releases_capacity(store):
     now = datetime.now(timezone.utc)
     controller = JobController(
         store,
         limits=StoreLimits(max_pending=1, max_retained=2),
         retention_seconds=60,
-        claim_lease_seconds=10,
+        worker_lease_seconds=10,
         clock=lambda: now,
         id_factory=lambda: "job_abandoned",
     )
     abandoned = _create(controller)
-    controller.claim_next_job("lost-worker")
+    _claim(controller, "lost-worker")
 
     recovery = JobController(
         store,
         limits=StoreLimits(max_pending=1, max_retained=2),
         retention_seconds=60,
-        claim_lease_seconds=10,
+        worker_lease_seconds=10,
         clock=lambda: now + timedelta(seconds=11),
         id_factory=lambda: "job_replacement",
     )
-    assert recovery.renew_claim(abandoned.id, "lost-worker") is None
+    assert recovery.register_worker("lost-worker") is None
     assert recovery.is_stop_requested(abandoned.id, "lost-worker") is True
     assert recovery.expire_worker_claims() == [abandoned.id]
     failed = recovery.get_job(abandoned.id)
@@ -863,4 +976,5 @@ def test_expired_worker_claim_fails_job_and_releases_capacity(store):
         "worker_lost",
         "The optimization worker stopped before the job completed.",
     )
+    assert recovery.register_worker("lost-worker")
     assert _create(recovery).state == JobState.QUEUED

--- a/core/tests/test_optimize_job_backends.py
+++ b/core/tests/test_optimize_job_backends.py
@@ -47,6 +47,7 @@ from nurse_scheduling.server.jobs.models import (
     OptimizationResult,
     StoredArtifact,
     StoreLimits,
+    WorkerLease,
 )
 from nurse_scheduling.server.retry import DEFAULT_RETRY_MAX_ATTEMPTS
 from nurse_scheduling.server.stores.memory import MemoryJobStore
@@ -150,8 +151,9 @@ def _create(controller, input_name="input.yaml"):
 
 
 def _claim(controller, worker_id="worker"):
-    assert controller.register_worker(worker_id)
-    return controller.claim_next_job(worker_id)
+    lease = controller.register_worker(worker_id)
+    assert lease is not None
+    return lease, controller.claim_next_job(lease)
 
 
 def _raise_watch_error_once(store, monkeypatch) -> None:
@@ -332,17 +334,18 @@ def test_store_round_trips_lifecycle_input_events_and_artifact(store):
     assert created.queue_position == 1
     assert controller.get_input(created.id) == b"apiVersion: alpha\n"
 
-    claimed = _claim(controller)
+    lease, claimed = _claim(controller)
     assert claimed is not None
     assert claimed.state == JobState.RUNNING
     assert claimed.worker_id == "worker"
 
-    controller.record_event(claimed.id, "job.phase_changed", {"message": "Solving"})
+    controller.record_event(claimed.id, "job.phase_changed", {"message": "Solving"}, lease=lease)
     artifact = StoredArtifact("input.xlsx", "application/test", b"xlsx")
     completed = controller.complete_job(
         claimed.id,
         OptimizationResult(OptimizationOutcome.OPTIMAL, 42, "OPTIMAL", "optimality_proven"),
         artifact,
+        lease=lease,
     )
     assert completed.state == JobState.COMPLETED
     assert completed.result is not None
@@ -378,13 +381,14 @@ def test_store_reports_missing_input_and_artifacts(store):
     with pytest.raises(JobInputNotFoundError):
         controller.get_input(created.id)
 
-    claimed = _claim(controller)
+    lease, claimed = _claim(controller)
     assert claimed is not None
     artifact = StoredArtifact("input.xlsx", "application/test", b"xlsx")
     controller.complete_job(
         claimed.id,
         OptimizationResult(OptimizationOutcome.OPTIMAL, 42, "OPTIMAL", "optimality_proven"),
         artifact,
+        lease=lease,
     )
     if isinstance(store, MemoryJobStore):
         store._records[created.id].artifacts.clear()
@@ -396,9 +400,10 @@ def test_store_reports_missing_input_and_artifacts(store):
 
 def test_store_handles_empty_queries_and_missing_jobs(store):
     now = datetime.now(timezone.utc)
+    lease = WorkerLease("worker", "token", now + timedelta(seconds=30))
 
-    assert store.register_worker("worker", now, now + timedelta(seconds=30))
-    assert store.claim_next_job("worker", now) is None
+    assert store.register_worker(lease, now)
+    assert store.claim_next_job(lease, now) is None
     assert store.find_finished_before(now) == []
     assert store.find_jobs_without_live_workers(now) == []
     store.check_health()
@@ -483,13 +488,14 @@ def test_redis_store_uses_artifact_metadata_defaults(fake_redis_store_factory):
     store = fake_redis_store_factory()
     controller = _controller(store)
     created = _create(controller)
-    claimed = _claim(controller)
+    lease, claimed = _claim(controller)
     assert claimed is not None
     artifact = StoredArtifact("input.xlsx", "application/test", b"xlsx")
     controller.complete_job(
         claimed.id,
         OptimizationResult(OptimizationOutcome.OPTIMAL, 42, "OPTIMAL", "optimality_proven"),
         artifact,
+        lease=lease,
     )
 
     store._redis.delete(store._artifact_metadata_key(created.id))
@@ -504,17 +510,18 @@ def test_redis_store_uses_artifact_metadata_defaults(fake_redis_store_factory):
 def test_redis_store_removes_corrupt_queue_entries(fake_redis_store_factory):
     store = fake_redis_store_factory()
     now = datetime.now(timezone.utc)
-    assert store.register_worker("worker", now, now + timedelta(seconds=30))
+    lease = WorkerLease("worker", "token", now + timedelta(seconds=30))
+    assert store.register_worker(lease, now)
     store._redis.zadd(store._queue_key, {"orphan": now.timestamp()})
 
-    assert store.claim_next_job("worker", now) is None
+    assert store.claim_next_job(lease, now) is None
 
     controller = _controller(store, now=now)
     created = _create(controller)
     controller.cancel_job(created.id)
     store._redis.zadd(store._queue_key, {created.id: now.timestamp()})
 
-    assert store.claim_next_job("worker", now) is None
+    assert store.claim_next_job(lease, now) is None
 
 
 def test_redis_event_stream_treats_socket_timeout_as_keepalive(fake_redis_store_factory, monkeypatch):
@@ -546,20 +553,22 @@ def test_redis_store_retries_watch_errors(fake_redis_store_factory, monkeypatch,
         return
 
     if operation == "renew":
-        assert controller.register_worker("worker")
+        lease = controller.register_worker("worker")
+        assert lease is not None
         _raise_watch_error_once(store, monkeypatch)
-        assert controller.renew_worker("worker")
+        assert controller.renew_worker(lease)
         return
 
     created = _create(controller)
     if operation == "delete":
         created = controller.cancel_job(created.id)
     if operation == "claim":
-        assert controller.register_worker("worker")
+        lease = controller.register_worker("worker")
+        assert lease is not None
     _raise_watch_error_once(store, monkeypatch)
 
     if operation == "claim":
-        assert controller.claim_next_job("worker").state == JobState.RUNNING
+        assert controller.claim_next_job(lease).state == JobState.RUNNING
     elif operation == "update":
         assert controller.cancel_job(created.id).state == JobState.CANCELLED
     else:
@@ -571,29 +580,29 @@ def test_redis_store_retries_watch_errors(fake_redis_store_factory, monkeypatch,
 def test_store_rejects_events_from_stale_workers_and_terminal_jobs(store):
     controller = _controller(store)
     created = _create(controller)
-    claimed = _claim(controller)
+    lease, claimed = _claim(controller)
     assert claimed is not None
 
     accepted = controller.record_score_and_event(
         claimed.id,
         42,
         {"source": "accepted"},
-        worker_id="worker",
+        lease=lease,
     )
     stale = controller.record_event(
         claimed.id,
         "job.phase_changed",
         {"source": "stale"},
-        worker_id="other-worker",
+        lease=WorkerLease("worker", "stale", lease.expires_at),
     )
     assert stale.revision == accepted.revision
 
-    terminal = controller.fail_job(claimed.id, JobFailure("solver_failed", "failed"))
+    terminal = controller.fail_job(claimed.id, JobFailure("solver_failed", "failed"), lease=lease)
     late = controller.record_event(
         claimed.id,
         "job.phase_changed",
         {"source": "late"},
-        worker_id="worker",
+        lease=lease,
     )
     assert late.revision == terminal.revision
 
@@ -650,12 +659,15 @@ def test_controller_cancellation_policy_is_shared_by_stores(store):
     assert cancelled.state == JobState.CANCELLED
 
     running = _create(controller, "running.yaml")
-    _claim(controller)
+    lease, _claimed = _claim(controller)
     cancelling = controller.cancel_job(running.id)
     assert cancelling.state == JobState.CANCELLING
-    stale = controller.complete_cancellation(running.id, "other-worker")
+    stale = controller.complete_cancellation(
+        running.id,
+        WorkerLease("other-worker", "stale", lease.expires_at),
+    )
     assert stale.state == JobState.CANCELLING
-    cancelled = controller.complete_cancellation(running.id, "worker")
+    cancelled = controller.complete_cancellation(running.id, lease)
     assert cancelled.state == JobState.CANCELLED
     assert cancelled.failure == JobFailure("cancelled", "Optimization cancelled.")
 
@@ -699,8 +711,9 @@ def test_store_claims_each_job_at_most_once_under_concurrency(store):
     created_ids = {_create(controller, f"{index}.yaml").id for index in range(6)}
 
     with ThreadPoolExecutor(max_workers=6) as executor:
-        claimed = list(executor.map(lambda index: _claim(controller, f"worker-{index}"), range(6)))
+        claims = list(executor.map(lambda index: _claim(controller, f"worker-{index}"), range(6)))
 
+    claimed = [job for _lease, job in claims]
     claimed_ids = {job.id for job in claimed if job is not None}
     assert claimed_ids == created_ids
     assert len(claimed_ids) == len(claimed)
@@ -713,8 +726,8 @@ def test_store_reports_job_and_worker_activity_across_lifecycle(store):
     _create(controller, "second.yaml")
     _create(controller, "third.yaml")
 
-    first_running = _claim(controller, "worker-1")
-    second_running = _claim(controller, "worker-2")
+    first_lease, first_running = _claim(controller, "worker-1")
+    _second_lease, second_running = _claim(controller, "worker-2")
     assert first_running is not None
     assert second_running is not None
     controller.cancel_job(first.id)
@@ -725,8 +738,8 @@ def test_store_reports_job_and_worker_activity_across_lifecycle(store):
     assert activity.cancelling_jobs == 1
     assert activity.online_workers == 2
 
-    controller.complete_cancellation(first.id, "worker-1")
-    third_running = controller.claim_next_job("worker-1")
+    controller.complete_cancellation(first.id, first_lease)
+    third_running = controller.claim_next_job(first_lease)
     assert third_running is not None
     activity = controller.get_activity()
     assert activity.queued_jobs == 0
@@ -745,12 +758,16 @@ def test_expired_worker_lease_cannot_be_renewed_and_can_be_replaced(store):
         clock=lambda: now[0],
     )
 
-    assert controller.register_worker("worker") == now[0] + timedelta(seconds=10)
+    lease = controller.register_worker("worker")
+    assert lease is not None
+    assert lease.expires_at == now[0] + timedelta(seconds=10)
     now[0] += timedelta(seconds=10)
-    assert controller.renew_worker("worker") is None
+    assert controller.renew_worker(lease) is None
     assert controller.get_activity().online_workers == 0
     assert store.remove_expired_worker_leases(now[0]) == ["worker"]
-    assert controller.register_worker("worker") == now[0] + timedelta(seconds=10)
+    replacement = controller.register_worker("worker")
+    assert replacement is not None
+    assert replacement.expires_at == now[0] + timedelta(seconds=10)
     assert controller.get_activity().online_workers == 1
 
 
@@ -764,7 +781,7 @@ def test_expired_worker_lease_rejects_late_terminal_outcomes(store):
         clock=lambda: now[0],
     )
     created = _create(controller)
-    claimed = _claim(controller)
+    lease, claimed = _claim(controller)
     assert claimed is not None
     now[0] += timedelta(seconds=11)
 
@@ -773,19 +790,75 @@ def test_expired_worker_lease_rejects_late_terminal_outcomes(store):
         created.id,
         OptimizationResult(OptimizationOutcome.OPTIMAL, 42, "OPTIMAL", "optimality_proven"),
         artifact,
+        lease=lease,
     )
-    after_failure = controller.fail_job(created.id, JobFailure("late_failure", "late"))
+    after_failure = controller.fail_job(created.id, JobFailure("late_failure", "late"), lease=lease)
 
     assert after_completion.state == JobState.RUNNING
     assert after_failure.state == JobState.RUNNING
     assert after_failure.revision == claimed.revision
     cancelling = controller.cancel_job(created.id)
-    after_cancellation = controller.complete_cancellation(created.id, "worker")
+    after_cancellation = controller.complete_cancellation(created.id, lease)
     assert cancelling.state == JobState.CANCELLING
     assert after_cancellation.state == JobState.CANCELLING
     assert after_cancellation.revision == cancelling.revision
     with pytest.raises(JobArtifactNotFoundError):
         store.get_artifact(created.id, artifact.name)
+
+
+def test_worker_completion_is_rejected_when_ownership_is_lost_before_atomic_update():
+    class OwnershipLostBeforeUpdateStore(MemoryJobStore):
+        lose_ownership_before_update = False
+
+        def update_job(self, job, expected_revision, events, artifact=None, **kwargs):
+            if self.lose_ownership_before_update and job.worker_id is not None:
+                self.lose_ownership_before_update = False
+                self.unregister_worker(kwargs["worker_lease"])
+            return super().update_job(job, expected_revision, events, artifact, **kwargs)
+
+    store = OwnershipLostBeforeUpdateStore()
+    controller = _controller(store)
+    created = _create(controller)
+    lease, claimed = _claim(controller)
+    assert claimed is not None
+    store.lose_ownership_before_update = True
+
+    after_completion = controller.complete_job(
+        created.id,
+        OptimizationResult(OptimizationOutcome.OPTIMAL, 42, "OPTIMAL", "optimality_proven"),
+        StoredArtifact("late.xlsx", "application/test", b"late"),
+        lease=lease,
+    )
+
+    assert after_completion.state == JobState.RUNNING
+    assert after_completion.revision == claimed.revision
+    with pytest.raises(JobArtifactNotFoundError):
+        store.get_artifact(created.id, "late.xlsx")
+
+
+def test_store_atomically_rejects_an_owned_update_after_lease_removal(store):
+    now = datetime.now(timezone.utc)
+    controller = _controller(store)
+    created = _create(controller)
+    lease = WorkerLease("worker", "lease-token", now + timedelta(seconds=30))
+    assert store.register_worker(lease, now)
+    claimed = store.claim_next_job(lease, now)
+    assert claimed is not None
+    store.unregister_worker(lease)
+
+    after_update = store.update_job(
+        replace(claimed, state=JobState.COMPLETED, finished_at=now),
+        claimed.revision,
+        [],
+        StoredArtifact("late.xlsx", "application/test", b"late"),
+        worker_lease=lease,
+        worker_lease_observed_at=now,
+    )
+
+    assert after_update.state == JobState.RUNNING
+    assert after_update.revision == claimed.revision
+    with pytest.raises(JobArtifactNotFoundError):
+        store.get_artifact(created.id, "late.xlsx")
 
 
 def test_revision_prevents_late_overwrite(store):
@@ -874,7 +947,7 @@ def test_completed_job_can_resume_after_client_sleeps(store):
         clock=lambda: now,
     )
     created = _create(controller)
-    running = _claim(controller)
+    lease, running = _claim(controller)
     assert running is not None
 
     event_stream = controller.stream_events(running.id, after_id=None, keepalive_seconds=0.01)
@@ -889,6 +962,7 @@ def test_completed_job_can_resume_after_client_sleeps(store):
         running.id,
         OptimizationResult(OptimizationOutcome.OPTIMAL, 42, "OPTIMAL", "optimality_proven"),
         artifact,
+        lease=lease,
     )
 
     after_sleep = JobController(
@@ -957,7 +1031,7 @@ def test_expired_worker_lease_fails_job_and_releases_capacity(store):
         id_factory=lambda: "job_abandoned",
     )
     abandoned = _create(controller)
-    _claim(controller, "lost-worker")
+    lost_lease, _running = _claim(controller, "lost-worker")
 
     recovery = JobController(
         store,
@@ -968,7 +1042,7 @@ def test_expired_worker_lease_fails_job_and_releases_capacity(store):
         id_factory=lambda: "job_replacement",
     )
     assert recovery.register_worker("lost-worker") is None
-    assert recovery.is_stop_requested(abandoned.id, "lost-worker") is True
+    assert recovery.is_stop_requested(abandoned.id, lost_lease) is True
     assert recovery.expire_worker_claims() == [abandoned.id]
     failed = recovery.get_job(abandoned.id)
     assert failed.state == JobState.FAILED

--- a/core/tests/test_serve.py
+++ b/core/tests/test_serve.py
@@ -1204,6 +1204,62 @@ def test_worker_reconciles_renewal_that_committed_before_response_was_lost():
         worker.stop()
 
 
+def test_worker_discards_recovery_lease_if_shutdown_wins_race(monkeypatch):
+    store = MemoryJobStore()
+    controller = JobController(
+        store,
+        limits=StoreLimits(max_pending=1, max_retained=2),
+        retention_seconds=60,
+        worker_lease_seconds=0.03,
+    )
+
+    class ControllerWithBlockedRecovery:
+        def __init__(self, delegate):
+            self.delegate = delegate
+            self.registration_count = 0
+            self.recovery_started = threading.Event()
+            self.recovery_allowed = threading.Event()
+
+        def __getattr__(self, name):
+            return getattr(self.delegate, name)
+
+        def register_worker(self, worker_id):
+            self.registration_count += 1
+            if self.registration_count > 1:
+                self.recovery_started.set()
+                self.recovery_allowed.wait(timeout=1)
+            return self.delegate.register_worker(worker_id)
+
+        def renew_worker(self, _lease):
+            raise ConnectionError("simulated heartbeat outage")
+
+    worker_controller = ControllerWithBlockedRecovery(controller)
+    worker = JobWorker(
+        worker_controller,
+        SuccessfulRunner(),
+        worker_id="worker",
+        claim_poll_seconds=0.005,
+        worker_lease_seconds=0.03,
+    )
+
+    worker.start()
+    try:
+        assert worker_controller.recovery_started.wait(timeout=1)
+        heartbeat_thread = worker._heartbeat_thread
+        assert heartbeat_thread is not None
+        monkeypatch.setattr(heartbeat_thread, "join", lambda timeout=None: None)
+
+        worker.stop()
+        worker_controller.recovery_allowed.set()
+        threading.Thread.join(heartbeat_thread, timeout=1)
+
+        assert not heartbeat_thread.is_alive()
+        assert controller.get_activity().online_workers == 0
+    finally:
+        worker_controller.recovery_allowed.set()
+        worker.stop()
+
+
 def test_cancel_queued_job_is_immediately_terminal():
     with _client(start_background=False) as client:
         created = _create(client).json()

--- a/core/tests/test_serve.py
+++ b/core/tests/test_serve.py
@@ -1045,7 +1045,7 @@ def test_optimization_runner_ignores_stop_requested_after_solver_returns(monkeyp
     assert output.result.termination_reason == "solver_timeout"
 
 
-def test_worker_survives_when_failure_persistence_also_fails(monkeypatch):
+def test_worker_exits_when_unreportable_failure_cleanup_fails(monkeypatch):
     job = Job(
         id="job_store_failure",
         state=JobState.RUNNING,
@@ -1062,13 +1062,12 @@ def test_worker_survives_when_failure_persistence_also_fails(monkeypatch):
     class FailingController:
         def __init__(self):
             self.claim_calls = 0
-            self.next_claim_attempted = threading.Event()
+            self.cleanup_attempted = threading.Event()
 
         def claim_next_job(self, _lease):
             self.claim_calls += 1
             if self.claim_calls == 1:
                 return job
-            self.next_claim_attempted.set()
             return None
 
         def register_worker(self, worker_id):
@@ -1078,7 +1077,8 @@ def test_worker_survives_when_failure_persistence_also_fails(monkeypatch):
             return WorkerLease(lease.worker_id, lease.token, datetime.now(timezone.utc) + timedelta(seconds=60))
 
         def unregister_worker(self, _lease):
-            return None
+            self.cleanup_attempted.set()
+            raise ConnectionError("store still unavailable")
 
         def get_input(self, _job_id):
             raise ConnectionError("store unavailable")
@@ -1098,8 +1098,84 @@ def test_worker_survives_when_failure_persistence_also_fails(monkeypatch):
 
     worker.start()
     try:
-        assert controller.next_claim_attempted.wait(timeout=1)
+        assert controller.cleanup_attempted.wait(timeout=1)
+        deadline = time.monotonic() + 1
+        while worker.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.005)
+        assert not worker.is_alive()
+        assert not worker.is_ready()
+    finally:
+        worker.stop()
+
+
+def test_worker_recovers_after_releasing_unreportable_failure_lease(monkeypatch):
+    store = MemoryJobStore()
+    controller = JobController(
+        store,
+        limits=StoreLimits(max_pending=2, max_retained=4),
+        retention_seconds=60,
+        worker_lease_seconds=0.15,
+    )
+    first = controller.create_job(
+        input_name="first.yaml",
+        client_id="client",
+        solver="ortools/cp-sat",
+        prettify=True,
+        timeout_seconds=60,
+        input_bytes=b"apiVersion: alpha\n",
+    )
+    second = controller.create_job(
+        input_name="second.yaml",
+        client_id="client",
+        solver="ortools/cp-sat",
+        prettify=True,
+        timeout_seconds=60,
+        input_bytes=b"apiVersion: alpha\n",
+    )
+
+    class ControllerWithReportingFailure:
+        def __init__(self, delegate):
+            self.delegate = delegate
+            self.failure_write_attempted = threading.Event()
+            self.second_claimed = threading.Event()
+
+        def __getattr__(self, name):
+            return getattr(self.delegate, name)
+
+        def claim_next_job(self, lease):
+            claimed = self.delegate.claim_next_job(lease)
+            if claimed is not None and claimed.id == second.id:
+                self.second_claimed.set()
+            return claimed
+
+        def get_input(self, job_id):
+            if job_id == first.id:
+                raise ConnectionError("input read failed")
+            return self.delegate.get_input(job_id)
+
+        def fail_job(self, job_id, failure, *, lease):
+            if job_id == first.id and not self.failure_write_attempted.is_set():
+                self.failure_write_attempted.set()
+                raise ConnectionError("failure write failed")
+            return self.delegate.fail_job(job_id, failure, lease=lease)
+
+    worker_controller = ControllerWithReportingFailure(controller)
+    monkeypatch.setattr("nurse_scheduling.server.jobs.worker.capture_optimize_exception", lambda *_args: None)
+    worker = JobWorker(
+        worker_controller,
+        SuccessfulRunner(),
+        worker_id="worker",
+        claim_poll_seconds=0.005,
+        worker_lease_seconds=0.15,
+    )
+
+    worker.start()
+    try:
+        assert worker_controller.failure_write_attempted.wait(timeout=1)
+        assert worker_controller.second_claimed.wait(timeout=2)
         assert worker.is_alive()
+        assert _wait_for_worker_ready(worker)
+        assert controller.get_job(first.id).state.terminal
     finally:
         worker.stop()
 

--- a/core/tests/test_serve.py
+++ b/core/tests/test_serve.py
@@ -250,6 +250,13 @@ def _wait_for_terminal(client: TestClient, job_id: str) -> dict:
     raise AssertionError(f"Job did not finish: {job_id}")
 
 
+def _wait_for_worker_ready(worker: JobWorker, timeout: float = 2) -> bool:
+    deadline = time.monotonic() + timeout
+    while not worker.is_ready() and time.monotonic() < deadline:
+        time.sleep(0.005)
+    return worker.is_ready()
+
+
 def test_info_and_readiness_report_status_without_caching():
     with _client(start_background=False) as client:
         info = client.get("/info")
@@ -1138,7 +1145,7 @@ def test_worker_uses_registered_lease_expiration_as_heartbeat_deadline():
     worker.start()
     try:
         assert controller.recovered.wait(timeout=1)
-        assert worker.is_ready()
+        assert _wait_for_worker_ready(worker)
     finally:
         worker.stop()
 
@@ -1628,7 +1635,7 @@ def test_worker_recovers_after_presence_lease_expires():
     try:
         assert runner.started.wait(timeout=2)
         assert worker_controller.recovered.wait(timeout=2)
-        assert worker.is_ready()
+        assert _wait_for_worker_ready(worker)
         failed = controller.get_job(created.id)
         assert failed.state == JobState.FAILED
         assert failed.failure is not None

--- a/core/tests/test_serve.py
+++ b/core/tests/test_serve.py
@@ -53,6 +53,7 @@ from nurse_scheduling.server.jobs.models import (
     OptimizationResult,
     StoredArtifact,
     StoreLimits,
+    WorkerLease,
 )
 from nurse_scheduling.server.jobs.process_executor import (
     ChildOptimizationError,
@@ -295,8 +296,9 @@ def test_info_reports_cancelling_jobs_separately():
     with _client(start_background=False) as client:
         created = _create(client).json()
         controller = client.app.state.job_controller
-        assert controller.register_worker("test-worker")
-        assert controller.claim_next_job("test-worker") is not None
+        lease = controller.register_worker("test-worker")
+        assert lease is not None
+        assert controller.claim_next_job(lease) is not None
         controller.cancel_job(created["id"])
 
         info = client.get("/info")
@@ -1055,26 +1057,26 @@ def test_worker_survives_when_failure_persistence_also_fails(monkeypatch):
             self.claim_calls = 0
             self.next_claim_attempted = threading.Event()
 
-        def claim_next_job(self, _worker_id):
+        def claim_next_job(self, _lease):
             self.claim_calls += 1
             if self.claim_calls == 1:
                 return job
             self.next_claim_attempted.set()
             return None
 
-        def register_worker(self, _worker_id):
-            return datetime.now(timezone.utc) + timedelta(seconds=60)
+        def register_worker(self, worker_id):
+            return WorkerLease(worker_id, "lease-token", datetime.now(timezone.utc) + timedelta(seconds=60))
 
-        def renew_worker(self, _worker_id):
-            return datetime.now(timezone.utc) + timedelta(seconds=60)
+        def renew_worker(self, lease):
+            return WorkerLease(lease.worker_id, lease.token, datetime.now(timezone.utc) + timedelta(seconds=60))
 
-        def unregister_worker(self, _worker_id):
+        def unregister_worker(self, _lease):
             return None
 
         def get_input(self, _job_id):
             raise ConnectionError("store unavailable")
 
-        def fail_job(self, _job_id, _failure):
+        def fail_job(self, _job_id, _failure, *, lease):
             raise ConnectionError("store still unavailable")
 
     controller = FailingController()
@@ -1101,20 +1103,24 @@ def test_worker_uses_registered_lease_expiration_as_heartbeat_deadline():
             self.registration_count = 0
             self.recovered = threading.Event()
 
-        def register_worker(self, _worker_id):
+        def register_worker(self, worker_id):
             self.registration_count += 1
             if self.registration_count > 1:
                 self.recovered.set()
             lifetime_seconds = 0.03 if self.registration_count == 1 else 60
-            return datetime.now(timezone.utc) + timedelta(seconds=lifetime_seconds)
+            return WorkerLease(
+                worker_id,
+                f"lease-token-{self.registration_count}",
+                datetime.now(timezone.utc) + timedelta(seconds=lifetime_seconds),
+            )
 
-        def renew_worker(self, _worker_id):
+        def renew_worker(self, _lease):
             raise ConnectionError("simulated heartbeat outage")
 
-        def unregister_worker(self, _worker_id):
+        def unregister_worker(self, _lease):
             return None
 
-        def claim_next_job(self, _worker_id):
+        def claim_next_job(self, _lease):
             return None
 
         def expire_worker_claims(self):
@@ -1133,6 +1139,67 @@ def test_worker_uses_registered_lease_expiration_as_heartbeat_deadline():
     try:
         assert controller.recovered.wait(timeout=1)
         assert worker.is_ready()
+    finally:
+        worker.stop()
+
+
+def test_worker_reconciles_renewal_that_committed_before_response_was_lost():
+    store = MemoryJobStore()
+    controller = JobController(
+        store,
+        limits=StoreLimits(max_pending=1, max_retained=2),
+        retention_seconds=60,
+        worker_lease_seconds=0.15,
+    )
+
+    class ControllerWithLostRenewalResponse:
+        def __init__(self, delegate):
+            self.delegate = delegate
+            self.registration_count = 0
+            self.initial_expiry = None
+            self.response_lost = threading.Event()
+            self.renewal_reconciled = threading.Event()
+            self.reregistered = threading.Event()
+
+        def __getattr__(self, name):
+            return getattr(self.delegate, name)
+
+        def register_worker(self, worker_id):
+            registered = self.delegate.register_worker(worker_id)
+            if registered is not None:
+                self.registration_count += 1
+                self.initial_expiry = registered.expires_at
+                if self.registration_count > 1:
+                    self.reregistered.set()
+            return registered
+
+        def renew_worker(self, lease):
+            renewed = self.delegate.renew_worker(lease)
+            if not self.response_lost.is_set():
+                assert self.initial_expiry is not None
+                while datetime.now(timezone.utc) < self.initial_expiry:
+                    time.sleep(0.001)
+                self.response_lost.set()
+                raise ConnectionError("renewal committed but response was lost")
+            self.renewal_reconciled.set()
+            return renewed
+
+    worker_controller = ControllerWithLostRenewalResponse(controller)
+    worker = JobWorker(
+        worker_controller,
+        SuccessfulRunner(),
+        worker_id="worker",
+        claim_poll_seconds=0.005,
+        worker_lease_seconds=0.15,
+    )
+
+    worker.start()
+    try:
+        assert worker_controller.response_lost.wait(timeout=1)
+        assert worker_controller.renewal_reconciled.wait(timeout=1)
+        assert not worker_controller.reregistered.is_set()
+        assert worker.is_ready()
+        assert worker_controller.registration_count == 1
     finally:
         worker.stop()
 
@@ -1232,11 +1299,11 @@ def test_worker_renews_presence_during_long_running_job():
         def __getattr__(self, name):
             return getattr(self.delegate, name)
 
-        def renew_worker(self, worker_id):
+        def renew_worker(self, lease):
             self.renewal_allowed.wait(timeout=2)
-            renewed = self.delegate.renew_worker(worker_id)
+            renewed = self.delegate.renew_worker(lease)
             if renewed:
-                self.renewed_expiry = store._workers[worker_id].expires_at
+                self.renewed_expiry = store._workers[lease.worker_id].expires_at
                 self.worker_renewed.set()
             return renewed
 
@@ -1414,18 +1481,18 @@ def test_worker_stops_execution_after_its_lease_expires():
         def __getattr__(self, name):
             return getattr(self.delegate, name)
 
-        def claim_next_job(self, worker_id):
+        def claim_next_job(self, lease):
             self.claim_calls += 1
-            claimed = self.delegate.claim_next_job(worker_id)
+            claimed = self.delegate.claim_next_job(lease)
             if self.claim_calls > 1:
                 self.next_claim_attempted.set()
             return claimed
 
-        def is_stop_requested(self, job_id, worker_id):
+        def is_stop_requested(self, job_id, lease):
             if not self.stop_read_failed.is_set():
                 self.stop_read_failed.set()
                 raise ConnectionError("store temporarily unavailable")
-            return self.delegate.is_stop_requested(job_id, worker_id)
+            return self.delegate.is_stop_requested(job_id, lease)
 
     worker_controller = ControllerWithTransientStopReadFailure(controller)
     runner = StoppableRunner()
@@ -1488,7 +1555,7 @@ def test_worker_recovers_after_presence_lease_expires():
                     self.recovered.set()
             return registered
 
-        def renew_worker(self, _worker_id):
+        def renew_worker(self, _lease):
             raise ConnectionError("simulated heartbeat outage")
 
     worker_controller = ControllerWithRenewalOutage(controller)

--- a/core/tests/test_serve.py
+++ b/core/tests/test_serve.py
@@ -1605,6 +1605,7 @@ def test_worker_recovers_after_presence_lease_expires():
         def __init__(self, delegate):
             self.delegate = delegate
             self.registration_count = 0
+            self.renewal_outage = threading.Event()
             self.recovered = threading.Event()
 
         def __getattr__(self, name):
@@ -1618,8 +1619,10 @@ def test_worker_recovers_after_presence_lease_expires():
                     self.recovered.set()
             return registered
 
-        def renew_worker(self, _lease):
-            raise ConnectionError("simulated heartbeat outage")
+        def renew_worker(self, lease):
+            if self.renewal_outage.is_set():
+                raise ConnectionError("simulated heartbeat outage")
+            return self.delegate.renew_worker(lease)
 
     worker_controller = ControllerWithRenewalOutage(controller)
     runner = IgnoringStopRunner()
@@ -1634,6 +1637,7 @@ def test_worker_recovers_after_presence_lease_expires():
     worker.start()
     try:
         assert runner.started.wait(timeout=2)
+        worker_controller.renewal_outage.set()
         assert worker_controller.recovered.wait(timeout=2)
         assert _wait_for_worker_ready(worker)
         failed = controller.get_job(created.id)

--- a/core/tests/test_serve.py
+++ b/core/tests/test_serve.py
@@ -282,10 +282,12 @@ def test_info_and_readiness_report_status_without_caching():
 
 
 def test_info_reports_shared_job_and_worker_activity():
-    runner = StoppableRunner()
-    with _client(runner) as client:
+    with _client(start_background=False) as client:
         first = _create(client).json()
-        assert runner.started.wait(timeout=2)
+        controller = client.app.state.job_controller
+        lease = controller.register_worker("test-worker")
+        assert lease is not None
+        assert controller.claim_next_job(lease) is not None
         second = _create(client).json()
 
         info = client.get("/info")
@@ -296,7 +298,7 @@ def test_info_reports_shared_job_and_worker_activity():
 
         client.post(f"/optimize/{first['id']}/cancel")
         client.post(f"/optimize/{second['id']}/cancel")
-        _wait_for_terminal(client, first["id"])
+        controller.complete_cancellation(first["id"], lease)
 
 
 def test_info_reports_cancelling_jobs_separately():
@@ -1110,11 +1112,13 @@ def test_worker_exits_when_unreportable_failure_cleanup_fails(monkeypatch):
 
 def test_worker_recovers_after_releasing_unreportable_failure_lease(monkeypatch):
     store = MemoryJobStore()
+    job_ids = iter(["job_first", "job_second"])
     controller = JobController(
         store,
         limits=StoreLimits(max_pending=2, max_retained=4),
         retention_seconds=60,
         worker_lease_seconds=0.15,
+        id_factory=lambda: next(job_ids),
     )
     first = controller.create_job(
         input_name="first.yaml",

--- a/core/tests/test_serve.py
+++ b/core/tests/test_serve.py
@@ -264,11 +264,45 @@ def test_info_and_readiness_report_status_without_caching():
             "started_at": client.app.state.started_at.isoformat(),
             "job_backend": "memory",
             "job_store_id": client.app.state.job_store.store_id,
+            "jobs": {"running": 0, "queued": 0, "cancelling": 0},
+            "workers": {"online": 0},
         }
         assert ready.json() == {"status": "ready"}
         assert info.headers["cache-control"] == "no-store"
         assert ready.headers["cache-control"] == "no-store"
         assert client.get("/health").status_code == 404
+
+
+def test_info_reports_shared_job_and_worker_activity():
+    runner = StoppableRunner()
+    with _client(runner) as client:
+        first = _create(client).json()
+        assert runner.started.wait(timeout=2)
+        second = _create(client).json()
+
+        info = client.get("/info")
+
+        assert info.status_code == 200
+        assert info.json()["jobs"] == {"running": 1, "queued": 1, "cancelling": 0}
+        assert info.json()["workers"] == {"online": 1}
+
+        client.post(f"/optimize/{first['id']}/cancel")
+        client.post(f"/optimize/{second['id']}/cancel")
+        _wait_for_terminal(client, first["id"])
+
+
+def test_info_reports_cancelling_jobs_separately():
+    with _client(start_background=False) as client:
+        created = _create(client).json()
+        controller = client.app.state.job_controller
+        assert controller.register_worker("test-worker")
+        assert controller.claim_next_job("test-worker") is not None
+        controller.cancel_job(created["id"])
+
+        info = client.get("/info")
+
+        assert info.json()["jobs"] == {"running": 0, "queued": 0, "cancelling": 1}
+        assert info.json()["workers"] == {"online": 1}
 
 
 def test_default_memory_store_uses_the_process_instance_identity():
@@ -466,7 +500,7 @@ def test_job_creation_offloads_the_synchronous_store_write():
     ("updates", "message"),
     [
         ({"claim_poll_seconds": 0}, "claim_poll_seconds must be positive"),
-        ({"claim_lease_seconds": 0}, "claim_lease_seconds must be positive"),
+        ({"worker_lease_seconds": 0}, "worker_lease_seconds must be positive"),
         ({"maintenance_interval_seconds": 0}, "maintenance_interval_seconds must be positive"),
         ({"sse_keepalive_seconds": 0}, "sse_keepalive_seconds must be positive"),
         ({"timeout_grace_seconds": 0}, "timeout_grace_seconds must be positive"),
@@ -509,7 +543,7 @@ def test_runtime_deployment_identity_is_shared_within_one_server_launch(monkeypa
     "name",
     [
         "claim_poll_seconds",
-        "claim_lease_seconds",
+        "worker_lease_seconds",
         "maintenance_interval_seconds",
         "sse_keepalive_seconds",
         "timeout_grace_seconds",
@@ -1028,6 +1062,15 @@ def test_worker_survives_when_failure_persistence_also_fails(monkeypatch):
             self.next_claim_attempted.set()
             return None
 
+        def register_worker(self, _worker_id):
+            return datetime.now(timezone.utc) + timedelta(seconds=60)
+
+        def renew_worker(self, _worker_id):
+            return datetime.now(timezone.utc) + timedelta(seconds=60)
+
+        def unregister_worker(self, _worker_id):
+            return None
+
         def get_input(self, _job_id):
             raise ConnectionError("store unavailable")
 
@@ -1041,13 +1084,55 @@ def test_worker_survives_when_failure_persistence_also_fails(monkeypatch):
         SuccessfulRunner(),
         worker_id="worker",
         claim_poll_seconds=0.005,
-        claim_lease_seconds=60,
+        worker_lease_seconds=60,
     )
 
     worker.start()
     try:
         assert controller.next_claim_attempted.wait(timeout=1)
         assert worker.is_alive()
+    finally:
+        worker.stop()
+
+
+def test_worker_uses_registered_lease_expiration_as_heartbeat_deadline():
+    class LeaseController:
+        def __init__(self):
+            self.registration_count = 0
+            self.recovered = threading.Event()
+
+        def register_worker(self, _worker_id):
+            self.registration_count += 1
+            if self.registration_count > 1:
+                self.recovered.set()
+            lifetime_seconds = 0.03 if self.registration_count == 1 else 60
+            return datetime.now(timezone.utc) + timedelta(seconds=lifetime_seconds)
+
+        def renew_worker(self, _worker_id):
+            raise ConnectionError("simulated heartbeat outage")
+
+        def unregister_worker(self, _worker_id):
+            return None
+
+        def claim_next_job(self, _worker_id):
+            return None
+
+        def expire_worker_claims(self):
+            return []
+
+    controller = LeaseController()
+    worker = JobWorker(
+        controller,
+        SuccessfulRunner(),
+        worker_id="worker",
+        claim_poll_seconds=0.005,
+        worker_lease_seconds=60,
+    )
+
+    worker.start()
+    try:
+        assert controller.recovered.wait(timeout=1)
+        assert worker.is_ready()
     finally:
         worker.stop()
 
@@ -1118,14 +1203,14 @@ def test_finish_now_completes_with_current_feasible_result():
         assert runner.finished.is_set()
 
 
-def test_worker_renews_claim_during_long_running_job():
+def test_worker_renews_presence_during_long_running_job():
     now = [datetime.now(timezone.utc)]
     store = MemoryJobStore()
     controller = JobController(
         store,
         limits=StoreLimits(max_pending=1, max_retained=2),
         retention_seconds=60,
-        claim_lease_seconds=0.06,
+        worker_lease_seconds=0.06,
         clock=lambda: now[0],
     )
     created = controller.create_job(
@@ -1141,18 +1226,18 @@ def test_worker_renews_claim_during_long_running_job():
         def __init__(self, delegate):
             self.delegate = delegate
             self.renewal_allowed = threading.Event()
-            self.claim_renewed = threading.Event()
-            self.renewed_job = None
+            self.worker_renewed = threading.Event()
+            self.renewed_expiry = None
 
         def __getattr__(self, name):
             return getattr(self.delegate, name)
 
-        def renew_claim(self, job_id, worker_id):
+        def renew_worker(self, worker_id):
             self.renewal_allowed.wait(timeout=2)
-            renewed = self.delegate.renew_claim(job_id, worker_id)
-            if renewed is not None:
-                self.renewed_job = renewed
-                self.claim_renewed.set()
+            renewed = self.delegate.renew_worker(worker_id)
+            if renewed:
+                self.renewed_expiry = store._workers[worker_id].expires_at
+                self.worker_renewed.set()
             return renewed
 
     worker_controller = ControllerWithRenewalSignal(controller)
@@ -1162,17 +1247,17 @@ def test_worker_renews_claim_during_long_running_job():
         runner,
         worker_id="worker",
         claim_poll_seconds=0.005,
-        claim_lease_seconds=0.06,
+        worker_lease_seconds=0.06,
     )
 
     worker.start()
     try:
         assert runner.started.wait(timeout=2)
-        initial_claim = controller.get_job(created.id)
+        initial_expiry = store._workers["worker"].expires_at
         now[0] += timedelta(seconds=0.01)
         worker_controller.renewal_allowed.set()
-        assert worker_controller.claim_renewed.wait(timeout=2)
-        assert worker_controller.renewed_job.claim_expires_at > initial_claim.claim_expires_at
+        assert worker_controller.worker_renewed.wait(timeout=2)
+        assert worker_controller.renewed_expiry > initial_expiry
 
         running = controller.get_job(created.id)
         assert running.state == JobState.RUNNING
@@ -1187,14 +1272,14 @@ def test_worker_renews_claim_during_long_running_job():
         worker.stop()
 
 
-def test_worker_shutdown_stops_child_and_leaves_claim_for_expiry():
+def test_worker_shutdown_stops_child_and_releases_worker_lease():
     now = [datetime.now(timezone.utc)]
     store = MemoryJobStore()
     controller = JobController(
         store,
         limits=StoreLimits(max_pending=1, max_retained=2),
         retention_seconds=60,
-        claim_lease_seconds=30,
+        worker_lease_seconds=30,
         clock=lambda: now[0],
     )
     created = controller.create_job(
@@ -1211,7 +1296,7 @@ def test_worker_shutdown_stops_child_and_leaves_claim_for_expiry():
         runner,
         worker_id="worker",
         claim_poll_seconds=0.005,
-        claim_lease_seconds=30,
+        worker_lease_seconds=30,
     )
 
     worker.start()
@@ -1226,7 +1311,6 @@ def test_worker_shutdown_stops_child_and_leaves_claim_for_expiry():
             process.name == f"optimization-job-{created.id}" for process in multiprocessing.active_children()
         )
 
-        now[0] += timedelta(seconds=31)
         assert controller.expire_worker_claims() == [created.id]
         failed = controller.get_job(created.id)
         assert failed.state == JobState.FAILED
@@ -1242,7 +1326,7 @@ def test_worker_cancellation_takes_priority_over_concurrent_shutdown(monkeypatch
         store,
         limits=StoreLimits(max_pending=1, max_retained=2),
         retention_seconds=60,
-        claim_lease_seconds=30,
+        worker_lease_seconds=30,
     )
     created = controller.create_job(
         input_name="input.yaml",
@@ -1282,7 +1366,7 @@ def test_worker_cancellation_takes_priority_over_concurrent_shutdown(monkeypatch
         SuccessfulRunner(),
         worker_id="worker",
         claim_poll_seconds=0.005,
-        claim_lease_seconds=30,
+        worker_lease_seconds=30,
     )
 
     worker.start()
@@ -1301,14 +1385,14 @@ def test_worker_cancellation_takes_priority_over_concurrent_shutdown(monkeypatch
         worker.stop()
 
 
-def test_worker_stops_execution_after_its_claim_expires():
+def test_worker_stops_execution_after_its_lease_expires():
     now = [datetime.now(timezone.utc)]
     store = MemoryJobStore()
     controller = JobController(
         store,
         limits=StoreLimits(max_pending=1, max_retained=2),
         retention_seconds=60,
-        claim_lease_seconds=30,
+        worker_lease_seconds=30,
         clock=lambda: now[0],
     )
     created = controller.create_job(
@@ -1350,7 +1434,7 @@ def test_worker_stops_execution_after_its_claim_expires():
         runner,
         worker_id="worker",
         claim_poll_seconds=0.005,
-        claim_lease_seconds=30,
+        worker_lease_seconds=30,
     )
 
     worker.start()
@@ -1366,6 +1450,66 @@ def test_worker_stops_execution_after_its_claim_expires():
         assert failed.failure is not None
         assert failed.failure.code == "worker_lost"
         assert worker.is_alive()
+    finally:
+        worker.stop()
+
+
+def test_worker_recovers_after_presence_lease_expires():
+    store = MemoryJobStore()
+    controller = JobController(
+        store,
+        limits=StoreLimits(max_pending=1, max_retained=2),
+        retention_seconds=60,
+        worker_lease_seconds=0.06,
+    )
+    created = controller.create_job(
+        input_name="input.yaml",
+        client_id="client",
+        solver="ortools/cp-sat",
+        prettify=True,
+        timeout_seconds=60,
+        input_bytes=b"apiVersion: alpha\n",
+    )
+
+    class ControllerWithRenewalOutage:
+        def __init__(self, delegate):
+            self.delegate = delegate
+            self.registration_count = 0
+            self.recovered = threading.Event()
+
+        def __getattr__(self, name):
+            return getattr(self.delegate, name)
+
+        def register_worker(self, worker_id):
+            registered = self.delegate.register_worker(worker_id)
+            if registered:
+                self.registration_count += 1
+                if self.registration_count > 1:
+                    self.recovered.set()
+            return registered
+
+        def renew_worker(self, _worker_id):
+            raise ConnectionError("simulated heartbeat outage")
+
+    worker_controller = ControllerWithRenewalOutage(controller)
+    runner = IgnoringStopRunner()
+    worker = JobWorker(
+        worker_controller,
+        runner,
+        worker_id="worker",
+        claim_poll_seconds=0.005,
+        worker_lease_seconds=0.06,
+    )
+
+    worker.start()
+    try:
+        assert runner.started.wait(timeout=2)
+        assert worker_controller.recovered.wait(timeout=2)
+        assert worker.is_ready()
+        failed = controller.get_job(created.id)
+        assert failed.state == JobState.FAILED
+        assert failed.failure is not None
+        assert failed.failure.code == "worker_lost"
     finally:
         worker.stop()
 

--- a/core/tests/test_serve.py
+++ b/core/tests/test_serve.py
@@ -69,6 +69,9 @@ from nurse_scheduling.server.solver_capabilities import SOLVER_CAPABILITIES
 from nurse_scheduling.server.stores.memory import MemoryJobStore
 
 
+PROCESS_START_TIMEOUT_SECONDS = 10
+
+
 class SuccessfulRunner:
     def run(self, job, input_bytes, *, event_callback, should_stop):
         event_callback("job.phase_changed", {"message": "Solving"}, None)
@@ -255,6 +258,34 @@ def _wait_for_worker_ready(worker: JobWorker, timeout: float = 2) -> bool:
     while not worker.is_ready() and time.monotonic() < deadline:
         time.sleep(0.005)
     return worker.is_ready()
+
+
+def _install_waiting_process_executor(monkeypatch) -> threading.Event:
+    process_started = threading.Event()
+
+    def wait_for_control(runner, job, input_bytes, *, event_callback, control, **_kwargs):
+        process_started.set()
+        while True:
+            requested = control()
+            if requested is ProcessControl.FINISH:
+                output = runner.run(
+                    job,
+                    input_bytes,
+                    event_callback=event_callback,
+                    should_stop=lambda: True,
+                )
+                return ProcessResult(status=ProcessStatus.COMPLETED, output=output)
+            if requested is ProcessControl.CANCEL:
+                return ProcessResult(status=ProcessStatus.CANCELLED)
+            if requested is ProcessControl.ABORT:
+                return ProcessResult(status=ProcessStatus.ABORTED)
+            time.sleep(0.001)
+
+    monkeypatch.setattr(
+        "nurse_scheduling.server.jobs.worker.run_optimization_process",
+        wait_for_control,
+    )
+    return process_started
 
 
 def test_info_and_readiness_report_status_without_caching():
@@ -1231,53 +1262,52 @@ def test_worker_uses_registered_lease_expiration_as_heartbeat_deadline():
 
 
 def test_worker_reconciles_renewal_that_committed_before_response_was_lost():
-    store = MemoryJobStore()
-    controller = JobController(
-        store,
-        limits=StoreLimits(max_pending=1, max_retained=2),
-        retention_seconds=60,
-        worker_lease_seconds=0.15,
-    )
-
     class ControllerWithLostRenewalResponse:
-        def __init__(self, delegate):
-            self.delegate = delegate
+        def __init__(self):
             self.registration_count = 0
-            self.initial_expiry = None
+            self.committed_lease = None
             self.response_lost = threading.Event()
             self.renewal_reconciled = threading.Event()
             self.reregistered = threading.Event()
 
-        def __getattr__(self, name):
-            return getattr(self.delegate, name)
-
         def register_worker(self, worker_id):
-            registered = self.delegate.register_worker(worker_id)
-            if registered is not None:
-                self.registration_count += 1
-                self.initial_expiry = registered.expires_at
-                if self.registration_count > 1:
-                    self.reregistered.set()
-            return registered
+            self.registration_count += 1
+            if self.registration_count > 1:
+                self.reregistered.set()
+            return WorkerLease(
+                worker_id,
+                f"lease-token-{self.registration_count}",
+                datetime.now(timezone.utc) - timedelta(seconds=1),
+            )
 
         def renew_worker(self, lease):
-            renewed = self.delegate.renew_worker(lease)
-            if not self.response_lost.is_set():
-                assert self.initial_expiry is not None
-                while datetime.now(timezone.utc) < self.initial_expiry:
-                    time.sleep(0.001)
+            if self.committed_lease is None:
+                self.committed_lease = WorkerLease(
+                    lease.worker_id,
+                    lease.token,
+                    datetime.now(timezone.utc) + timedelta(seconds=60),
+                )
                 self.response_lost.set()
                 raise ConnectionError("renewal committed but response was lost")
             self.renewal_reconciled.set()
-            return renewed
+            return self.committed_lease
 
-    worker_controller = ControllerWithLostRenewalResponse(controller)
+        def unregister_worker(self, _lease):
+            return None
+
+        def claim_next_job(self, _lease):
+            return None
+
+        def expire_worker_claims(self):
+            return []
+
+    worker_controller = ControllerWithLostRenewalResponse()
     worker = JobWorker(
         worker_controller,
         SuccessfulRunner(),
         worker_id="worker",
         claim_poll_seconds=0.005,
-        worker_lease_seconds=0.15,
+        worker_lease_seconds=60,
     )
 
     worker.start()
@@ -1285,7 +1315,7 @@ def test_worker_reconciles_renewal_that_committed_before_response_was_lost():
         assert worker_controller.response_lost.wait(timeout=1)
         assert worker_controller.renewal_reconciled.wait(timeout=1)
         assert not worker_controller.reregistered.is_set()
-        assert worker.is_ready()
+        assert _wait_for_worker_ready(worker)
         assert worker_controller.registration_count == 1
     finally:
         worker.stop()
@@ -1361,7 +1391,7 @@ def test_cancel_running_job_stops_worker_and_discards_result():
     runner = StoppableRunner()
     with _client(runner) as client:
         created = _create(client).json()
-        assert runner.started.wait(timeout=2)
+        assert runner.started.wait(timeout=PROCESS_START_TIMEOUT_SECONDS)
         response = client.post(f"/optimize/{created['id']}/cancel")
         assert response.status_code == 202
         assert response.json()["state"] in {"cancelling", "cancelled"}
@@ -1381,7 +1411,7 @@ def test_cancellation_immediately_terminates_the_solver_process(solver):
     runner = IgnoringStopRunner()
     with _client(runner) as client:
         created = _create(client, solver=solver).json()
-        assert runner.started.wait(timeout=2)
+        assert runner.started.wait(timeout=PROCESS_START_TIMEOUT_SECONDS)
         running = client.get(f"/optimize/{created['id']}").json()
         assert running["controls"]["cancellable"] is True
         response = client.post(f"/optimize/{created['id']}/cancel")
@@ -1402,7 +1432,7 @@ def test_finish_now_completes_with_current_feasible_result():
     runner = StoppableRunner()
     with _client(runner) as client:
         created = _create(client).json()
-        assert runner.started.wait(timeout=2)
+        assert runner.started.wait(timeout=PROCESS_START_TIMEOUT_SECONDS)
         response = client.post(f"/optimize/{created['id']}/finish-now")
         assert response.status_code == 202
         assert response.json()["controls"]["early_completion_available"] is False
@@ -1413,15 +1443,13 @@ def test_finish_now_completes_with_current_feasible_result():
         assert runner.finished.is_set()
 
 
-def test_worker_renews_presence_during_long_running_job():
-    now = [datetime.now(timezone.utc)]
+def test_worker_renews_presence_during_long_running_job(monkeypatch):
     store = MemoryJobStore()
     controller = JobController(
         store,
         limits=StoreLimits(max_pending=1, max_retained=2),
         retention_seconds=60,
-        worker_lease_seconds=0.06,
-        clock=lambda: now[0],
+        worker_lease_seconds=30,
     )
     created = controller.create_job(
         input_name="input.yaml",
@@ -1433,46 +1461,53 @@ def test_worker_renews_presence_during_long_running_job():
     )
 
     class ControllerWithRenewalSignal:
-        def __init__(self, delegate):
+        def __init__(self, delegate, process_started):
             self.delegate = delegate
-            self.renewal_allowed = threading.Event()
+            self.process_started = process_started
+            self.initial_expiry = None
             self.worker_renewed = threading.Event()
             self.renewed_expiry = None
 
         def __getattr__(self, name):
             return getattr(self.delegate, name)
 
+        def register_worker(self, worker_id):
+            registered = self.delegate.register_worker(worker_id)
+            if registered is not None:
+                self.initial_expiry = registered.expires_at
+            return registered
+
         def renew_worker(self, lease):
-            self.renewal_allowed.wait(timeout=2)
+            if not self.process_started.wait(timeout=2):
+                raise RuntimeError("execution did not start before worker renewal")
             renewed = self.delegate.renew_worker(lease)
             if renewed:
                 self.renewed_expiry = store._workers[lease.worker_id].expires_at
                 self.worker_renewed.set()
             return renewed
 
-    worker_controller = ControllerWithRenewalSignal(controller)
-    runner = StoppableRunner()
+    process_started = _install_waiting_process_executor(monkeypatch)
+    monkeypatch.setattr("nurse_scheduling.server.jobs.worker.CONTROL_POLL_SECONDS", 0.005)
+    worker_controller = ControllerWithRenewalSignal(controller, process_started)
     worker = JobWorker(
         worker_controller,
-        runner,
+        SuccessfulRunner(),
         worker_id="worker",
         claim_poll_seconds=0.005,
-        worker_lease_seconds=0.06,
+        worker_lease_seconds=30,
     )
+    worker._worker_heartbeat_seconds = 0.005
 
     worker.start()
     try:
-        assert runner.started.wait(timeout=2)
-        initial_expiry = store._workers["worker"].expires_at
-        now[0] += timedelta(seconds=0.01)
-        worker_controller.renewal_allowed.set()
+        assert process_started.wait(timeout=2)
         assert worker_controller.worker_renewed.wait(timeout=2)
-        assert worker_controller.renewed_expiry > initial_expiry
+        assert worker_controller.initial_expiry is not None
+        assert worker_controller.renewed_expiry > worker_controller.initial_expiry
 
         running = controller.get_job(created.id)
         assert running.state == JobState.RUNNING
         controller.request_early_completion(created.id)
-        assert runner.finished.wait(timeout=2)
         for _ in range(200):
             if controller.get_job(created.id).state == JobState.COMPLETED:
                 break
@@ -1511,7 +1546,7 @@ def test_worker_shutdown_stops_child_and_releases_worker_lease():
 
     worker.start()
     try:
-        assert runner.started.wait(timeout=2)
+        assert runner.started.wait(timeout=PROCESS_START_TIMEOUT_SECONDS)
         worker.stop()
 
         running = controller.get_job(created.id)
@@ -1595,7 +1630,7 @@ def test_worker_cancellation_takes_priority_over_concurrent_shutdown(monkeypatch
         worker.stop()
 
 
-def test_worker_stops_execution_after_its_lease_expires():
+def test_worker_stops_execution_after_its_lease_expires(monkeypatch):
     now = [datetime.now(timezone.utc)]
     store = MemoryJobStore()
     controller = JobController(
@@ -1638,10 +1673,11 @@ def test_worker_stops_execution_after_its_lease_expires():
             return self.delegate.is_stop_requested(job_id, lease)
 
     worker_controller = ControllerWithTransientStopReadFailure(controller)
-    runner = StoppableRunner()
+    process_started = _install_waiting_process_executor(monkeypatch)
+    monkeypatch.setattr("nurse_scheduling.server.jobs.worker.CONTROL_POLL_SECONDS", 0.005)
     worker = JobWorker(
         worker_controller,
-        runner,
+        SuccessfulRunner(),
         worker_id="worker",
         claim_poll_seconds=0.005,
         worker_lease_seconds=30,
@@ -1649,7 +1685,7 @@ def test_worker_stops_execution_after_its_lease_expires():
 
     worker.start()
     try:
-        assert runner.started.wait(timeout=2)
+        assert process_started.wait(timeout=2)
         assert worker_controller.stop_read_failed.wait(timeout=2)
         now[0] += timedelta(seconds=31)
         assert controller.expire_worker_claims() == [created.id]
@@ -1664,7 +1700,7 @@ def test_worker_stops_execution_after_its_lease_expires():
         worker.stop()
 
 
-def test_worker_recovers_after_presence_lease_expires():
+def test_worker_recovers_after_presence_lease_expires(monkeypatch):
     store = MemoryJobStore()
     controller = JobController(
         store,
@@ -1705,10 +1741,10 @@ def test_worker_recovers_after_presence_lease_expires():
             return self.delegate.renew_worker(lease)
 
     worker_controller = ControllerWithRenewalOutage(controller)
-    runner = IgnoringStopRunner()
+    process_started = _install_waiting_process_executor(monkeypatch)
     worker = JobWorker(
         worker_controller,
-        runner,
+        SuccessfulRunner(),
         worker_id="worker",
         claim_poll_seconds=0.005,
         worker_lease_seconds=0.06,
@@ -1716,7 +1752,7 @@ def test_worker_recovers_after_presence_lease_expires():
 
     worker.start()
     try:
-        assert runner.started.wait(timeout=2)
+        assert process_started.wait(timeout=2)
         worker_controller.renewal_outage.set()
         assert worker_controller.recovered.wait(timeout=2)
         assert _wait_for_worker_ready(worker)

--- a/docker/README.md
+++ b/docker/README.md
@@ -72,13 +72,13 @@ with:
 - `JOB_BACKEND=redis`
 - `JOB_REDIS_URL=redis://redis:6379/0`
 - `JOB_REDIS_KEY_PREFIX=nurse_scheduling:jobs:v0`
-- `JOB_CLAIM_LEASE_SECONDS=90` by default
+- `JOB_WORKER_LEASE_SECONDS=90` by default
 - `JOB_MAX_EVENTS_PER_JOB=1000` by default
 
 The API container runs multiple Uvicorn workers. Each worker claims jobs
-from Redis and runs at most one optimization job locally. Active workers renew
-their claims; a job is failed and its capacity is released if its worker stops
-renewing the claim.
+from Redis and runs at most one optimization job locally. Workers renew shared
+presence leases while idle and running. A job is failed and its capacity is
+released if its owning worker lease expires.
 
 To run one backend worker with process-local memory and no Redis service, use
 the pre-Redis deployment configuration:

--- a/docs/backend-server.md
+++ b/docs/backend-server.md
@@ -26,8 +26,10 @@ curl "$API_URL/info"
 ```
 
 `/ready` returns a minimal readiness result. `/info` also includes the API and
-application versions. Interactive OpenAPI documentation is available at
-`$API_URL/docs`, with the schema at `$API_URL/openapi.json`.
+application versions plus current worker status and activities.
+
+Interactive OpenAPI documentation is available at `$API_URL/docs`, with the
+schema at `$API_URL/openapi.json`.
 
 ## Architecture
 
@@ -75,12 +77,12 @@ flowchart TB
 | `server/jobs/worker.py` | Owns the process-local claim loop. It renews leases, coordinates the process executor, and reports the terminal outcome. |
 | `server/jobs/process_executor.py` | Runs one optimization in a spawned child process, bridges events and controls, and enforces timeout and cancellation boundaries without knowing about HTTP or persistence. |
 | `server/jobs/runner.py` | Adapts one blocking job execution to the synchronous scheduler. It normalizes progress and results and creates the XLSX artifact without knowing HTTP or persistence. |
-| `server/maintenance.py` | Expires lost worker claims and retained terminal jobs. |
+| `server/maintenance.py` | Expires jobs owned by lost workers, worker leases, and retained terminal jobs. |
 
 `nurse_scheduling.serve:app` is the public ASGI entry point. Each application
 process owns one worker thread and one maintenance thread. The worker renews its
-claim lease while a job is running. Each optimization runs in a separate child
-process.
+shared presence lease whether idle or running. Each optimization runs in a
+separate child process.
 
 The worker owns job lifecycle orchestration. The process executor owns child
 process supervision. The runner owns one scheduler invocation and its output
@@ -97,7 +99,7 @@ stateDiagram-v2
     running --> failed: failure
     running --> cancelling: cancel
     cancelling --> cancelled: process ends
-    cancelling --> cancelled: claim expires
+    cancelling --> cancelled: worker lease expires
     completed --> [*]
     cancelled --> [*]
     failed --> [*]
@@ -158,7 +160,7 @@ checkpointing it outside the child process.
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/` | Return API identity and version information. |
-| `GET` | `/info` | Check the store and worker, including version information. |
+| `GET` | `/info` | Check readiness and report versions, job activity, and online workers. |
 | `GET` | `/ready` | Return a minimal readiness result for routing and deployment probes. |
 | `POST` | `/optimize` | Validate multipart input and enqueue a job. |
 | `GET` | `/optimize/{job_id}` | Return the current job representation. |
@@ -255,7 +257,7 @@ All server settings are read once when the application is constructed.
 | `JOB_RETENTION_SECONDS` | `86400` | Retain terminal jobs for this duration. |
 | `JOB_MAX_EVENTS_PER_JOB` | `1000` | Limit replayable events retained per job. |
 | `JOB_CLAIM_POLL_SECONDS` | `1` | Set the delay between attempts to claim work. |
-| `JOB_CLAIM_LEASE_SECONDS` | `90` | Set how long a worker claim remains valid without renewal. |
+| `JOB_WORKER_LEASE_SECONDS` | `90` | Set how long a worker remains online without renewal. |
 | `JOB_MAINTENANCE_INTERVAL_SECONDS` | `30` | Set the delay between maintenance passes. |
 | `JOB_SSE_KEEPALIVE_SECONDS` | `10` | Set the maximum SSE wait before a keepalive. |
 | `OPTIMIZE_MAX_YAML_BYTES` | `2097152` | Limit the submitted YAML size. |

--- a/docs/backend-server.md
+++ b/docs/backend-server.md
@@ -39,10 +39,10 @@ flowchart TB
 
     subgraph Process[FastAPI process]
         API[<b>API routes</b><br/>HTTP job endpoints]
-        Controller[<b>JobController</b><br/>Lifecycle policy<br/>Persistence]
-        Worker[<b>JobWorker</b><br/>Claim and control jobs]
+        Controller[<b>JobController</b><br/>Job use cases<br/>Lifecycle policy]
+        Worker[<b>JobWorker</b><br/>Claim and execute jobs]
         Executor[<b>Process runner</b><br/>Spawn and supervise direct child]
-        Store[<b>JobStore</b><br/>Atomic job, event,<br/>and artifact storage]
+        Store[<b>JobStore</b><br/>Atomic job, lease,<br/>event, and artifact storage]
         Maintenance[<b>JobMaintenance</b><br/>Expire claims and jobs]
 
         subgraph Child[Per-job child process]
@@ -57,7 +57,7 @@ flowchart TB
     Client -->|Submit and control| API
     API -->|JSON, SSE, XLSX| Client
     API -->|Commands| Controller
-    Controller <--> Worker
+    Worker -->|Commands and outcomes| Controller
     Worker -->|Run job| Executor
     Executor <-->|Events, controls, result| Runner
     Runner -->|Schedule| Engine
@@ -68,25 +68,25 @@ flowchart TB
     Memory ~~~ Redis
 ```
 
-| Component | Responsibility |
-| --- | --- |
-| `server/app.py` | Constructs the FastAPI app, dependencies, background services, health checks, and error handlers. |
-| `server/api/` | Translates HTTP requests and responses, including the SSE event stream. |
-| `server/jobs/controller.py` | Owns job lifecycle policy independently of HTTP and persistence. |
-| `server/job_store.py` | Defines the atomic persistence contract implemented by memory and Redis stores. |
-| `server/jobs/worker.py` | Owns the process-local claim loop. It renews leases, coordinates the process executor, and reports the terminal outcome. |
-| `server/jobs/process_executor.py` | Runs one optimization in a spawned child process, bridges events and controls, and enforces timeout and cancellation boundaries without knowing about HTTP or persistence. |
-| `server/jobs/runner.py` | Adapts one blocking job execution to the synchronous scheduler. It normalizes progress and results and creates the XLSX artifact without knowing HTTP or persistence. |
-| `server/maintenance.py` | Expires jobs owned by lost workers, worker leases, and retained terminal jobs. |
+| Component | Control-flow role | Responsibility |
+| --- | --- | --- |
+| `server/app.py` | Bootstrap | Constructs the FastAPI app, dependencies, background services, health checks, and error handlers. |
+| `server/api/` | Reactive driver | Translates incoming HTTP requests into controller operations and returns HTTP or SSE responses. |
+| `server/jobs/controller.py` | Passive application service | Defines job use cases and lifecycle policy independently of HTTP, worker loops, and persistence implementations. |
+| `server/job_store.py` | Passive persistence boundary | Defines the atomic job and lease contract implemented by memory and Redis stores. |
+| `server/jobs/worker.py` | Active background driver | Owns the process-local claim and heartbeat loops, carries its current lease, coordinates execution, and reports outcomes through the controller. |
+| `server/jobs/process_executor.py` | Invoked service | Runs one optimization in a spawned child process, bridges events and controls, and enforces timeout and cancellation boundaries without knowing about HTTP or persistence. |
+| `server/jobs/runner.py` | Invoked adapter | Adapts one blocking job execution to the synchronous scheduler. It normalizes progress and results and creates the XLSX artifact without knowing HTTP or persistence. |
+| `server/maintenance.py` | Active background driver | Periodically asks the controller to expire jobs owned by lost workers, worker leases, and retained terminal jobs. |
 
 `nurse_scheduling.serve:app` is the public ASGI entry point. Each application
 process owns one worker thread and one maintenance thread. The worker renews its
 shared presence lease whether idle or running. Each optimization runs in a
 separate child process.
 
-The worker owns job lifecycle orchestration. The process executor owns child
-process supervision. The runner owns one scheduler invocation and its output
-conversion.
+The controller owns job lifecycle policy. The worker owns execution
+orchestration. The process executor owns child process supervision. The runner
+owns one scheduler invocation and its output conversion.
 
 ## Job Lifecycle
 
@@ -229,6 +229,9 @@ operations, `413` for oversized YAML, and `429` when job capacity is exhausted.
 Do not use memory mode with multiple Uvicorn workers. A later request may reach
 a different process that does not contain the job. Redis mode coordinates job
 claims across processes. Each process still executes at most one job at a time.
+Opaque lease tokens fence stale workers. Stores validate the job revision,
+lease, and active-job association together before accepting worker updates.
+Each execution retains the exact lease used to claim its job.
 
 Example with three server processes:
 

--- a/web-frontend/e2e/helpers.ts
+++ b/web-frontend/e2e/helpers.ts
@@ -150,6 +150,8 @@ export async function mockOptimizeAndExport(
         status: 'ready',
         api_version: 'test',
         app_version: 'test',
+        jobs: { running: 0, queued: 0, cancelling: 0 },
+        workers: { online: 1 },
       }),
     });
   });

--- a/web-frontend/e2e/optimize-and-export-http-server.spec.ts
+++ b/web-frontend/e2e/optimize-and-export-http-server.spec.ts
@@ -67,6 +67,8 @@ test('optimize and export works against a real local HTTP server instead of Play
         status: 'ready',
         api_version: 'alpha',
         app_version: 'v-test',
+        jobs: { running: 1, queued: 2, cancelling: 1 },
+        workers: { online: 3 },
       }));
       return;
     }
@@ -173,6 +175,8 @@ test('optimize and export works against a real local HTTP server instead of Play
     await page.keyboard.press('Enter');
 
     await expect(page.getByRole('button', { name: 'Optimize and Download' })).toBeEnabled();
+    await expect(page.getByText('2 active · 2 queued')).toHaveCount(2);
+    await expect(page.getByText('3 workers')).toHaveCount(2);
     await page.getByRole('button', { name: 'Optimize and Download' }).click();
 
     await expect(page.getByText('Schedule optimized and downloaded successfully!')).toBeVisible();

--- a/web-frontend/src/app/optimize-and-export/page.test.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.test.tsx
@@ -26,6 +26,7 @@ import OptimizeAndExportPage from '@/app/optimize-and-export/page';
 import {
   selectOfflineFallbackBackendApiUrl,
   selectPreferredServer,
+  type ServerInfoResponse,
 } from '@/app/optimize-and-export/serverSelection';
 
 const mockUseSchedulingData = vi.hoisted(() => vi.fn());
@@ -98,16 +99,14 @@ const createSchedulingData = (overrides = {}) => ({
   ...overrides,
 });
 
-const healthyResponse = (overrides: Partial<{
-  status: string;
-  api_version: string;
-  app_version: string;
-}> = {}) => ({
+const healthyResponse = (overrides: Partial<ServerInfoResponse> = {}) => ({
   ok: true,
   json: vi.fn().mockResolvedValue({
     status: 'ready',
     api_version: 'alpha',
     app_version: 'frontend-test',
+    jobs: { running: 0, queued: 0, cancelling: 0 },
+    workers: { online: 1 },
     ...overrides,
   }),
 });
@@ -316,14 +315,77 @@ describe('OptimizeAndExportPage error handling', () => {
         status: 'ready',
         api_version: 'alpha',
         app_version: 'v-test',
+        jobs: { running: 2, queued: 4, cancelling: 1 },
+        workers: { online: 5 },
       }),
     });
 
     render(<OptimizeAndExportPage />);
 
     await expect(screen.findByText('Server: Online')).resolves.toBeInTheDocument();
+    expect(screen.getAllByRole('columnheader').map(header => header.textContent)).toEqual([
+      'Server',
+      'Activity',
+      'Status',
+      'Actions',
+    ]);
     expect(screen.getByText(/API version: alpha · Frontend version: frontend-test · Backend version: v-test/)).toBeInTheDocument();
     expect(screen.getByText(/Last checked: .* · \d+ ms/)).toBeInTheDocument();
+    expect(screen.getAllByText('3 active · 4 queued')).toHaveLength(2);
+    expect(screen.getAllByText('5 workers')).toHaveLength(2);
+  });
+
+  it('shows unavailable activity for an older healthy backend response', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        status: 'ready',
+        api_version: 'alpha',
+        app_version: 'frontend-test',
+      }),
+    });
+
+    render(<OptimizeAndExportPage />);
+
+    await expect(screen.findByText('Server: Online')).resolves.toBeInTheDocument();
+    expect(screen.getAllByText('Activity unavailable')).toHaveLength(2);
+  });
+
+  it('silently refreshes activity while preserving the previous online snapshot', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    let resolveRefresh: (response: ReturnType<typeof healthyResponse>) => void = () => undefined;
+    fetchMock
+      .mockResolvedValueOnce(healthyResponse({
+        jobs: { running: 1, queued: 2, cancelling: 0 },
+        workers: { online: 3 },
+      }))
+      .mockImplementationOnce(() => new Promise(resolve => {
+        resolveRefresh = resolve;
+      }));
+    const setIntervalSpy = vi.spyOn(window, 'setInterval');
+
+    render(<OptimizeAndExportPage />);
+
+    await expect(screen.findByText('Server: Online')).resolves.toBeInTheDocument();
+    expect(screen.getAllByText('1 active · 2 queued')).toHaveLength(2);
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 15000);
+
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(screen.getByText('Server: Online')).toBeInTheDocument();
+    expect(screen.getAllByText('1 active · 2 queued')).toHaveLength(2);
+
+    act(() => {
+      resolveRefresh(healthyResponse({
+        jobs: { running: 2, queued: 1, cancelling: 1 },
+        workers: { online: 4 },
+      }));
+    });
+    await waitFor(() => {
+      expect(screen.getAllByText('3 active · 1 queued')).toHaveLength(2);
+      expect(screen.getAllByText('4 workers')).toHaveLength(2);
+    });
   });
 
   it('allows an empty solver timeout while editing and clears its run error only after a value change', async () => {
@@ -712,7 +774,7 @@ describe('OptimizeAndExportPage error handling', () => {
     render(<OptimizeAndExportPage />);
 
     await expect(screen.findByText('Server: Offline')).resolves.toBeInTheDocument();
-    expect(screen.getByText(/backend is not responding at the configured endpoint/i)).toBeInTheDocument();
+    expect(screen.getAllByText('Not responding')).toHaveLength(2);
     expect(screen.getByRole('button', { name: /optimize and download/i })).toBeDisabled();
     expect(screen.getByText(/backend unavailable/i)).toBeInTheDocument();
   });

--- a/web-frontend/src/app/optimize-and-export/page.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.tsx
@@ -111,6 +111,7 @@ interface StoredOptimizeServerOptions {
 const TERMINAL_JOB_STATES = new Set(['completed', 'cancelled', 'failed']);
 const HEALTH_CHECK_TIMEOUT_MS = 3000;
 const INITIAL_HEALTH_CHECK_TIMEOUT_MS = 3000;
+const SERVER_ACTIVITY_REFRESH_MS = 15000;
 const SERVER_OPTIONS_STORAGE_KEY = 'nurse-scheduling-optimize-server-options';
 const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
@@ -464,6 +465,7 @@ export default function OptimizeAndExportPage() {
   const pageMountIdRef = useRef(0);
   const latestHealthProbeIdRef = useRef(0);
   const serverProbeControllersRef = useRef<Map<string, AbortController>>(new Map());
+  const serverEntriesRef = useRef(serverEntries);
   const selectedServer = selectedServerEndpoint === 'auto'
     ? null
     : serverEntries.find(server => server.endpoint === selectedServerEndpoint) ?? null;
@@ -577,7 +579,11 @@ export default function OptimizeAndExportPage() {
     persistServerOptions(servers, nextSelectedServerEndpoint);
   }, [selectedServerEndpoint]);
 
-  const startServerCheck = useCallback((server: OptimizeServerEntry) => {
+  useEffect(() => {
+    serverEntriesRef.current = serverEntries;
+  }, [serverEntries]);
+
+  const startServerCheck = useCallback((server: OptimizeServerEntry, silent = false) => {
     const endpoint = normalizeEndpoint(server.endpoint);
     if (!endpoint) {
       return;
@@ -597,7 +603,7 @@ export default function OptimizeAndExportPage() {
         ? {
             ...currentServer,
             endpoint,
-            status: 'checking',
+            status: silent && currentServer.status !== 'unchecked' ? currentServer.status : 'checking',
             error: null,
             healthProbeId,
           }
@@ -651,6 +657,23 @@ export default function OptimizeAndExportPage() {
       if (pageMountIdRef.current === pageMountId) {
         pageMountIdRef.current += 1;
       }
+    };
+  }, [startServerCheck]);
+
+  useEffect(() => {
+    const refreshActivity = () => {
+      if (document.visibilityState !== 'visible') {
+        return;
+      }
+      serverEntriesRef.current.forEach(server => {
+        startServerCheck(server, true);
+      });
+    };
+    const intervalId = window.setInterval(refreshActivity, SERVER_ACTIVITY_REFRESH_MS);
+    document.addEventListener('visibilitychange', refreshActivity);
+    return () => {
+      window.clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', refreshActivity);
     };
   }, [startServerCheck]);
 
@@ -1161,7 +1184,7 @@ export default function OptimizeAndExportPage() {
               <span className="mt-1 block truncate text-xs text-gray-500">
                 Last checked: {formatCheckedTime(server.lastCheckedAt)}
                 {server.pingMs !== null ? ` · ${server.pingMs} ms` : ''}
-                {server.error ? ` · ${server.error}` : ''}
+                {server.error && server.error !== 'Backend is not responding.' ? ` · ${server.error}` : ''}
               </span>
             </span>
           </label>
@@ -1169,8 +1192,42 @@ export default function OptimizeAndExportPage() {
       },
     },
     {
+      header: 'Activity',
+      accessor: (row: BackendTableRow) => {
+        const server = row.kind === 'auto' ? resolvedServer : row.server;
+        const status = row.kind === 'auto' ? autoServerStatus : row.server.status;
+        if (status === 'offline') {
+          return <span className="text-sm font-normal text-red-600">Not responding</span>;
+        }
+        if (status === 'checking' && !server?.health) {
+          return <span className="text-sm font-normal text-gray-500">Checking...</span>;
+        }
+        if (!server?.health?.jobs || !server.health.workers) {
+          return (
+            <span className="text-sm font-normal text-gray-500">
+              {status === 'unchecked' ? 'Not checked' : 'Activity unavailable'}
+            </span>
+          );
+        }
+
+        const activeJobs = server.health.jobs.running + server.health.jobs.cancelling;
+        const onlineWorkers = server.health.workers.online;
+        return (
+          <span className="block min-h-10 font-normal">
+            <span className="block text-sm text-gray-800">
+              {activeJobs} active · {server.health.jobs.queued} queued
+            </span>
+            <span className="mt-0.5 block text-xs text-gray-500">
+              {onlineWorkers} {onlineWorkers === 1 ? 'worker' : 'workers'}
+            </span>
+          </span>
+        );
+      },
+    },
+    {
       header: 'Status',
       align: 'center' as const,
+      width: 80,
       accessor: (row: BackendTableRow) => {
         const status = row.kind === 'auto' ? autoServerStatus : row.server.status;
         const label = row.kind === 'auto'
@@ -1198,6 +1255,7 @@ export default function OptimizeAndExportPage() {
     {
       header: 'Actions',
       align: 'center' as const,
+      width: 80,
       accessor: (row: BackendTableRow) => {
         if (row.kind === 'auto') {
           return <span />;
@@ -1383,29 +1441,18 @@ export default function OptimizeAndExportPage() {
                 <p className="text-xs text-gray-500">Checking API endpoints...</p>
               )}
 
-              {(activeServerHealth || activeServerStatus === 'offline') && (
+              {activeServerHealth && (
                 <div className="space-y-2">
-                  {activeServerHealth && (
-                    <div className="rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
-                      <p>
-                        API version: {activeServerHealth.api_version} · Frontend version: {CURRENT_APP_VERSION} · Backend version: {activeServerHealth.app_version}
+                  <div className="rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
+                    <p>
+                      API version: {activeServerHealth.api_version} · Frontend version: {CURRENT_APP_VERSION} · Backend version: {activeServerHealth.app_version}
+                    </p>
+                    {hasVersionMismatch && (
+                      <p className="mt-1 font-medium text-amber-700">
+                        Frontend and backend versions do not match. If nothing breaks, you can continue.
                       </p>
-                      {hasVersionMismatch && (
-                        <p className="mt-1 font-medium text-amber-700">
-                          Frontend and backend versions do not match. If nothing breaks, you can continue.
-                        </p>
-                      )}
-                    </div>
-                  )}
-
-                  {activeServerStatus === 'offline' && (
-                    <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-                      <div className="flex gap-2">
-                        <FiAlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                        <span>Backend is not responding at the configured endpoint.</span>
-                      </div>
-                    </div>
-                  )}
+                    )}
+                  </div>
                 </div>
               )}
             </div>

--- a/web-frontend/src/app/optimize-and-export/serverSelection.ts
+++ b/web-frontend/src/app/optimize-and-export/serverSelection.ts
@@ -21,6 +21,14 @@ export interface ServerInfoResponse {
   status: string;
   api_version: string;
   app_version: string;
+  jobs?: {
+    running: number;
+    queued: number;
+    cancelling: number;
+  };
+  workers?: {
+    online: number;
+  };
 }
 
 export interface ServerInfoCheckResult {

--- a/web-frontend/src/components/DataTable.test.tsx
+++ b/web-frontend/src/components/DataTable.test.tsx
@@ -139,6 +139,26 @@ describe('DataTable', () => {
     expect(screen.getByText('Footer action')).toBeInTheDocument();
   });
 
+  it('only constrains a column width when the caller specifies one', () => {
+    const widthColumns = [
+      ...columns,
+      { header: 'Actions', accessor: () => 'Action', width: 80 },
+    ];
+
+    const { container } = render(
+      <DataTable<Row>
+        title="Rows"
+        columns={widthColumns}
+        data={[{ id: 'a', name: 'Alpha' }]}
+      />,
+    );
+
+    const headers = container.querySelectorAll('th');
+    expect(headers[0]).not.toHaveStyle({ width: '80px' });
+    expect(headers[1]).not.toHaveStyle({ width: '80px' });
+    expect(headers[2]).toHaveStyle({ width: '80px', minWidth: '80px', maxWidth: '80px' });
+  });
+
   it('keeps order unchanged when dropping onto the same row index', () => {
     const onReorder = vi.fn();
     const data: Row[] = [

--- a/web-frontend/src/components/DataTable.tsx
+++ b/web-frontend/src/components/DataTable.tsx
@@ -26,6 +26,7 @@ interface Column<T> {
   header: string;
   accessor: ((item: T, index: number) => ReactNode) | keyof T;
   align?: 'left' | 'center' | 'right';
+  width?: number;
 }
 
 interface DataTableProps<T> {
@@ -107,14 +108,14 @@ export function DataTable<T>({ title, columns, data, onReorder, getRowClassName,
           <tr>
             {columns.map((column, index) => {
               const isFirstColumn = index === 0;
-              const isThirdColumn = index === 2;
+              const width = column.width;
               return (
                 <th
                   key={index}
                   className={`px-2 ${isFirstColumn ? 'pl-4' : ''} py-3 text-xs font-medium text-gray-500 uppercase tracking-wider ${
                     column.align === 'right' ? 'text-right' : column.align === 'center' ? 'text-center' : 'text-left'
                   }`}
-                  style={isThirdColumn ? { width: '80px', minWidth: '80px', maxWidth: '80px' } : undefined}
+                  style={width ? { width, minWidth: width, maxWidth: width } : undefined}
                 >
                   {column.header}
                 </th>
@@ -143,14 +144,14 @@ export function DataTable<T>({ title, columns, data, onReorder, getRowClassName,
                 } ${customClassName}`}
               >
               {columns.map((column, colIndex) => {
-                const isThirdColumn = colIndex === 2;
+                const width = column.width;
                 return (
                   <td
                     key={colIndex}
                     className={`${colIndex === 0 ? 'pl-4 pr-2' : 'px-2'} py-1 whitespace-nowrap text-sm font-medium text-gray-900 ${
                       column.align === 'right' ? 'text-right' : column.align === 'center' ? 'text-center' : 'text-left'
                     }`}
-                    style={isThirdColumn ? { width: '80px', minWidth: '80px', maxWidth: '80px' } : undefined}
+                    style={width ? { width, minWidth: width, maxWidth: width } : undefined}
                   >
                     {typeof column.accessor === 'function'
                       ? column.accessor(item, rowIndex)

--- a/web-frontend/src/components/TableColumns.test.tsx
+++ b/web-frontend/src/components/TableColumns.test.tsx
@@ -103,6 +103,24 @@ function GroupTableHarness({
 }
 
 describe('TableColumns', () => {
+  it('keeps the shared Actions column constrained to 80 pixels', () => {
+    render(
+      <ItemTableHarness
+        items={[{ id: 'A', description: '' }]}
+        groups={[]}
+        onInlineEdit={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('columnheader', { name: 'Actions' })).toHaveStyle({
+      width: '80px',
+      minWidth: '80px',
+      maxWidth: '80px',
+    });
+  });
+
   it('triggers inline edit callback on double-clicking item ID', async () => {
     const user = userEvent.setup();
     const onInlineEdit = vi.fn();

--- a/web-frontend/src/components/TableColumns.tsx
+++ b/web-frontend/src/components/TableColumns.tsx
@@ -265,6 +265,7 @@ function useBaseTableColumns(
         );
       },
       align: 'center' as const,
+      width: 80,
     });
   }
 

--- a/web-frontend/src/components/TableColumns.tsx
+++ b/web-frontend/src/components/TableColumns.tsx
@@ -175,6 +175,7 @@ function useBaseTableColumns(
     header: string;
     accessor: (entity: Item | Group, index: number) => React.ReactElement;
     align?: 'left' | 'center' | 'right';
+    width?: number;
   }> = [
     {
       header: 'ID',


### PR DESCRIPTION
Querying worker capacity would require a mechanism exposing the number of workers. However, for future multi-node setup, it's non-straightforward to know the number of uvicorn workers on each node. We could use an environment variable to control this, but is quite manual and error-prone. Therefore, the more robust solution is to require each worker to register itself and maintain a lease, such that if that worker dies, the lease would expire and still maintain the correct count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **New Features**
  * Added worker presence leases with automatic renewal/recovery; job capacity is released when a worker lease expires.
  * Server `/info` now reports shared job activity (running/queued/cancelling) plus online worker counts; UI adds an “Activity” column and refreshes periodically.
  * Table columns support optional fixed widths (including the “Actions” column).

* **Bug Fixes**
  * `/info` safely degrades when activity data is unavailable.
  * Improved handling when a job’s owning worker lease is no longer live.

* **Documentation & Tests**
  * Updated lease configuration docs (now uses `JOB_WORKER_LEASE_SECONDS`) and refreshed backend/frontend/e2e tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->