### PR TITLE
feat: Add reset button highlight/disable based on whether server info is defualt

### DIFF
--- a/web-frontend/src/app/optimize-and-export/page.test.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.test.tsx
@@ -19,7 +19,7 @@
 
 // This test is mostly AI generated.
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react';
 import OptimizeAndExportPage from '@/app/optimize-and-export/page';
@@ -552,9 +552,12 @@ describe('OptimizeAndExportPage error handling', () => {
     expect(customResetButton).toHaveAttribute('title', 'Custom server settings active');
     expect(customResetButton.querySelector('[aria-hidden="true"]')).toHaveClass('bg-amber-500');
 
-    await user.click(customResetButton);
+    await user.dblClick(screen.getByTitle('https://stored-backend.example.test'));
+    expect(screen.getByDisplayValue('https://stored-backend.example.test')).toHaveFocus();
+    fireEvent.click(customResetButton);
 
-    await expect(screen.findByTitle(LOCAL_API_URL)).resolves.toBeInTheDocument();
+    const defaultBackend = await screen.findByTitle(LOCAL_API_URL);
+    expect(defaultBackend.closest('tr')).toHaveAttribute('draggable', 'true');
     const defaultResetButton = screen.getByRole('button', { name: 'Reset server settings to defaults' });
     expect(defaultResetButton).toBeDisabled();
     expect(defaultResetButton).not.toHaveAttribute('title');

--- a/web-frontend/src/app/optimize-and-export/page.test.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.test.tsx
@@ -533,6 +533,35 @@ describe('OptimizeAndExportPage error handling', () => {
     expect(fetchMock).not.toHaveBeenCalledWith(`${LOCAL_API_URL}/info`, expect.anything());
   });
 
+  it('highlights custom server settings and disables Reset after restoring defaults', async () => {
+    const user = userEvent.setup();
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(healthyResponse());
+    window.localStorage.setItem('nurse-scheduling-optimize-server-options', JSON.stringify({
+      servers: [{ endpoint: 'https://stored-backend.example.test' }],
+      selectedServerEndpoint: 'https://stored-backend.example.test',
+    }));
+
+    render(<OptimizeAndExportPage />);
+
+    await expect(screen.findByTitle('https://stored-backend.example.test')).resolves.toBeInTheDocument();
+    const customResetButton = screen.getByRole('button', {
+      name: /reset server settings to defaults.*custom server settings active/i,
+    });
+    expect(customResetButton).toBeEnabled();
+    expect(customResetButton).toHaveAttribute('title', 'Custom server settings active');
+    expect(customResetButton.querySelector('[aria-hidden="true"]')).toHaveClass('bg-amber-500');
+
+    await user.click(customResetButton);
+
+    await expect(screen.findByTitle(LOCAL_API_URL)).resolves.toBeInTheDocument();
+    const defaultResetButton = screen.getByRole('button', { name: 'Reset server settings to defaults' });
+    expect(defaultResetButton).toBeDisabled();
+    expect(defaultResetButton).not.toHaveAttribute('title');
+    expect(defaultResetButton.querySelector('[aria-hidden="true"]')).toBeNull();
+    expect(window.localStorage.getItem('nurse-scheduling-optimize-server-options')).toBeNull();
+  });
+
   it('selects a backend when clicking anywhere on its row', async () => {
     const user = userEvent.setup();
     const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;

--- a/web-frontend/src/app/optimize-and-export/page.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.tsx
@@ -1106,6 +1106,7 @@ export default function OptimizeAndExportPage() {
     const nextServers = createDefaultServerEntries();
     setServerEntries(nextServers);
     setSelectedServerEndpoint('auto');
+    setEditingServerEndpoint(null);
     setAddingServer(false);
     setAddServerError(null);
     nextServers.forEach(server => {

--- a/web-frontend/src/app/optimize-and-export/page.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.tsx
@@ -136,6 +136,15 @@ function createDefaultServerEntries(): OptimizeServerEntry[] {
   }));
 }
 
+function hasCustomServerOptions(
+  servers: OptimizeServerEntry[],
+  selectedServerEndpoint: ServerSelection,
+): boolean {
+  return selectedServerEndpoint !== 'auto'
+    || servers.length !== BACKEND_API_CANDIDATES.length
+    || servers.some((server, index) => normalizeEndpoint(server.endpoint) !== BACKEND_API_CANDIDATES[index]);
+}
+
 function toStoredServerOptions(
   servers: OptimizeServerEntry[],
   selectedServerEndpoint: ServerSelection,
@@ -1108,6 +1117,7 @@ export default function OptimizeAndExportPage() {
     { kind: 'auto' },
     ...serverEntries.map(server => ({ kind: 'server' as const, server })),
   ];
+  const hasCustomBackendSettings = hasCustomServerOptions(serverEntries, selectedServerEndpoint);
   const isEditingBackendServer = Boolean(editingServerEndpoint || addingServer);
   const finishBackendEndpointEdit = () => {
     setEditingServerEndpoint(null);
@@ -1126,10 +1136,17 @@ export default function OptimizeAndExportPage() {
       <button
         type="button"
         onClick={resetServers}
-        disabled={isOptimizing}
-        className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
+        disabled={isOptimizing || !hasCustomBackendSettings}
+        aria-label={hasCustomBackendSettings
+          ? 'Reset server settings to defaults. Custom server settings active.'
+          : 'Reset server settings to defaults'}
+        title={hasCustomBackendSettings ? 'Custom server settings active' : undefined}
+        className="inline-flex items-center justify-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
       >
         Reset
+        {hasCustomBackendSettings && (
+          <span aria-hidden="true" className="h-2 w-2 rounded-full bg-amber-500" />
+        )}
       </button>
     </div>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an amber visual/accessibility indicator when customized backend server settings are active.
  - Updated the Backend “Reset” control labeling and state to reflect whether custom settings are in use.

- **Bug Fixes**
  - Resetting backend server settings now properly restores defaults, clears saved custom settings, removes the custom indicator, disables the reset control, and clears any in-progress custom endpoint editing.

- **Tests**
  - Added coverage to verify the custom settings flow, reset interaction, and local settings cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->