### PR TITLE
feat(web-frontend): allow incompatible backend selection

### DIFF
--- a/web-frontend/AGENTS.md
+++ b/web-frontend/AGENTS.md
@@ -25,6 +25,10 @@ Playwright.
 `test:e2e:affected` does not infer browser coverage from changed `src/` files;
 pass relevant E2E spec paths explicitly when validating frontend behavior.
 
+Keep commit bodies focused on behavior and rationale. Do not mention routine
+test additions or regression coverage unless the test strategy itself is
+material to the change.
+
 To test specific source files from the repository root, run:
 
 ```sh

--- a/web-frontend/e2e/optimize-and-export-error.spec.ts
+++ b/web-frontend/e2e/optimize-and-export-error.spec.ts
@@ -62,3 +62,80 @@ test('optimize and export renders backend errors without a stale success state',
   await expect(page.getByText('Server error (500): solver unavailable')).toBeVisible();
   await expect(page.getByText('Schedule optimized and downloaded successfully!')).toHaveCount(0);
 });
+
+test('allows an explicitly selected incompatible backend with a warning', async ({ page }) => {
+  /*
+   * Steps:
+   * 1. Seed a valid schedule and return reachable backend information for an unsupported API version.
+   * 2. Confirm Auto declines the backend while preserving its activity and compatibility details.
+   * 3. Select the backend explicitly and confirm the warning action sends the request.
+   */
+  await seedSchedulingState(page, {
+    apiVersion: 'test',
+    description: 'incompatible backend seed',
+    dates: {
+      range: { startDate: '2026-05-01', endDate: '2026-05-01' },
+      items: [{ id: '01', description: '' }],
+      groups: [],
+    },
+    people: {
+      items: [{ id: 'P1', description: 'Primary nurse', history: [] }],
+      groups: [],
+      history: [],
+    },
+    shiftTypes: {
+      items: [{ id: 'D', description: 'Day' }],
+      groups: [],
+    },
+    preferences: [],
+    export: { formatting: [] },
+  });
+
+  let optimizeRequested = false;
+  await page.route('http://localhost:8000/info', async route => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        status: 'ready',
+        service_name: 'nurse-scheduling-api',
+        api_version: 'alpha',
+        app_version: 'old-backend',
+        jobs: { running: 1, queued: 3, cancelling: 1 },
+        workers: { online: 2 },
+      }),
+    });
+  });
+  await page.route('http://localhost:8000/optimize', async route => {
+    optimizeRequested = true;
+    await route.fulfill({
+      status: 422,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ detail: 'old API rejected request' }),
+    });
+  });
+
+  await page.goto('/optimize-and-export');
+
+  await expect(page.getByText('Server: Incompatible')).toBeVisible();
+  await expect(page.getByText('2 active · 3 queued')).toBeVisible();
+  await expect(page.getByText('2 workers')).toBeVisible();
+  await expect(page.getByLabel('http://localhost:8000 status: Incompatible')).toHaveAttribute('title', 'Incompatible');
+  await expect(page.getByText(/auto found no compatible backend/i)).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Optimize and Download' })).toBeDisabled();
+  await expect(page.getByText(/API version: alpha \(expected 0\.2\.0\)/i)).toHaveCount(0);
+
+  await page.getByLabel('Select http://localhost:8000').check({ force: true });
+
+  await expect(page.getByText(/API version: alpha \(expected 0\.2\.0\).*Frontend version:/i)).toBeVisible();
+  await expect(page.getByText('Incompatible backend. The request may fail.')).toBeVisible();
+  const optimizeButton = page.getByRole('button', { name: 'Optimize Anyway and Download' });
+  await expect(optimizeButton).toBeEnabled();
+  await optimizeButton.click();
+
+  await expect(page.getByText('Server error (422): old API rejected request')).toBeVisible();
+  expect(optimizeRequested).toBe(true);
+});

--- a/web-frontend/src/app/optimize-and-export/page.test.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.test.tsx
@@ -820,15 +820,51 @@ describe('OptimizeAndExportPage error handling', () => {
   });
 
   it.each([
-    ['an unexpected service', { service_name: 'different-service' }],
-    ['an unsupported API version', { api_version: '2' }],
-  ])('rejects %s during backend discovery', async (_label, overrides) => {
+    ['an unexpected service', { service_name: 'different-service' }, /service: different-service \(expected nurse-scheduling-api\)/i],
+    ['an unsupported API version', { api_version: '2' }, /API version: 2 \(expected 0\.2\.0\)/i],
+    ['a backend that is not ready', { status: 'starting' }, /status: starting \(expected ready\)/i],
+    ['missing app version metadata', { app_version: undefined }, /backend version: missing/i],
+  ])('warns about %s and allows explicit selection', async (_label, overrides, warning) => {
+    const user = userEvent.setup();
     (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(healthyResponse(overrides));
 
     render(<OptimizeAndExportPage />);
 
-    await expect(screen.findByText('Server: Offline')).resolves.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /optimize and download/i })).toBeDisabled();
+    await expect(screen.findByText('Server: Incompatible')).resolves.toBeInTheDocument();
+    expect(screen.queryByText('Not responding')).not.toBeInTheDocument();
+    expect(screen.getByText(/auto found no compatible backend/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Optimize and Download' })).toBeDisabled();
+    expect(screen.queryByText(warning)).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText(`Select ${LOCAL_API_URL}`));
+
+    expect(screen.getAllByText(warning).length).toBeGreaterThan(0);
+    expect(screen.getByText('Incompatible backend. The request may fail.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Optimize Anyway and Download' })).toBeEnabled();
+  });
+
+  it('sends to an explicitly selected incompatible backend', async () => {
+    const user = userEvent.setup();
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock
+      .mockResolvedValueOnce(healthyResponse({ api_version: 'alpha' }))
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        text: vi.fn().mockResolvedValue('request rejected by old API'),
+      });
+
+    render(<OptimizeAndExportPage />);
+
+    await screen.findByText('Server: Incompatible');
+    await user.click(screen.getByLabelText(`Select ${LOCAL_API_URL}`));
+    await user.click(screen.getByRole('button', { name: 'Optimize Anyway and Download' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      `${LOCAL_API_URL}/optimize`,
+      expect.objectContaining({ method: 'POST' })
+    ));
+    await expect(screen.findByText('Server error (422): request rejected by old API')).resolves.toBeInTheDocument();
   });
 
   it('keeps a successful download when best-effort job cleanup fails', async () => {

--- a/web-frontend/src/app/optimize-and-export/page.tsx
+++ b/web-frontend/src/app/optimize-and-export/page.tsx
@@ -22,7 +22,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import Link from 'next/link';
-import { FiDownload, FiAlertCircle, FiCheckCircle, FiLoader, FiRefreshCw, FiWifi, FiWifiOff, FiActivity, FiTrash2 } from 'react-icons/fi';
+import { FiDownload, FiAlertCircle, FiAlertTriangle, FiCheckCircle, FiLoader, FiRefreshCw, FiWifi, FiWifiOff, FiActivity, FiTrash2 } from 'react-icons/fi';
 import { DataTable } from '@/components/DataTable';
 import { InlineEdit } from '@/components/InlineEdit';
 import OptimizationProgressChart, { OptimizationProgressPoint } from '@/components/OptimizationProgressChart';
@@ -41,8 +41,14 @@ import {
 } from '@/app/optimize-and-export/serverSelection';
 import { CURRENT_APP_VERSION, parseVersionParts } from '@/utils/version';
 
-type ServerStatus = 'unchecked' | 'checking' | 'online' | 'offline';
+type ServerStatus = 'unchecked' | 'checking' | 'online' | 'incompatible' | 'offline';
 type ServerSelection = 'auto' | string;
+
+interface ServerInfoProbeResult {
+  status: 'online' | 'incompatible' | 'offline';
+  health: ServerInfoResponse | null;
+  error: string | null;
+}
 
 interface OptimizeJobResponse {
   id: string;
@@ -245,7 +251,7 @@ async function fetchServerInfo(
   endpoint: string,
   timeoutMs = HEALTH_CHECK_TIMEOUT_MS,
   signal?: AbortSignal,
-): Promise<ServerInfoResponse | null> {
+): Promise<ServerInfoProbeResult> {
   const controller = new AbortController();
   const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
   const abortController = () => controller.abort();
@@ -259,18 +265,83 @@ async function fetchServerInfo(
     });
 
     if (!response.ok) {
-      return null;
+      return {
+        status: 'offline',
+        health: null,
+        error: `Backend info request failed with status ${response.status}.`,
+      };
     }
 
-    const info = await response.json() as Partial<ServerInfoResponse>;
-    return info.status === 'ready'
-      && info.service_name === EXPECTED_BACKEND_SERVICE_NAME
-      && info.api_version === SUPPORTED_BACKEND_API_VERSION
-      && typeof info.app_version === 'string'
-      ? info as ServerInfoResponse
-      : null;
+    let payload: unknown;
+    try {
+      payload = await response.json() as unknown;
+    } catch {
+      return {
+        status: 'incompatible',
+        health: null,
+        error: 'Backend returned invalid server information.',
+      };
+    }
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      return {
+        status: 'incompatible',
+        health: null,
+        error: 'Backend returned invalid server information.',
+      };
+    }
+
+    const info = payload as Partial<ServerInfoResponse>;
+    const incompatibilities: string[] = [];
+    if (info.status !== 'ready') {
+      incompatibilities.push(
+        typeof info.status === 'string'
+          ? `Backend reports status "${info.status}". Expected "ready".`
+          : 'Backend readiness status is missing.'
+      );
+    }
+    if (info.service_name !== EXPECTED_BACKEND_SERVICE_NAME) {
+      incompatibilities.push(
+        typeof info.service_name === 'string'
+          ? `Unexpected service "${info.service_name}". Expected "${EXPECTED_BACKEND_SERVICE_NAME}".`
+          : 'Backend service name is missing.'
+      );
+    }
+    if (info.api_version !== SUPPORTED_BACKEND_API_VERSION) {
+      incompatibilities.push(
+        typeof info.api_version === 'string'
+          ? `Unsupported API version "${info.api_version}". Expected "${SUPPORTED_BACKEND_API_VERSION}".`
+          : 'Backend API version is missing.'
+      );
+    }
+    if (typeof info.app_version !== 'string') {
+      incompatibilities.push('Backend app version is missing.');
+    }
+
+    const health: ServerInfoResponse = {
+      status: typeof info.status === 'string' ? info.status : 'missing',
+      service_name: typeof info.service_name === 'string' ? info.service_name : 'missing',
+      api_version: typeof info.api_version === 'string' ? info.api_version : 'missing',
+      app_version: typeof info.app_version === 'string' ? info.app_version : 'missing',
+      jobs: info.jobs,
+      workers: info.workers,
+    };
+    return incompatibilities.length > 0
+      ? {
+          status: 'incompatible',
+          health,
+          error: incompatibilities.join(' '),
+        }
+      : {
+          status: 'online',
+          health,
+          error: null,
+        };
   } catch {
-    return null;
+    return {
+      status: 'offline',
+      health: null,
+      error: 'Backend is not responding.',
+    };
   } finally {
     window.clearTimeout(timeoutId);
     signal?.removeEventListener('abort', abortController);
@@ -414,6 +485,9 @@ function getServerStatusBadgeClasses(status: ServerStatus): string {
   if (status === 'online') {
     return 'bg-green-50 text-green-700 ring-green-200';
   }
+  if (status === 'incompatible') {
+    return 'bg-amber-50 text-amber-700 ring-amber-200';
+  }
   if (status === 'offline') {
     return 'bg-red-50 text-red-700 ring-red-200';
   }
@@ -429,6 +503,9 @@ function formatServerStatus(status: ServerStatus): string {
   }
   if (status === 'online') {
     return 'Online';
+  }
+  if (status === 'incompatible') {
+    return 'Incompatible';
   }
   if (status === 'offline') {
     return 'Offline';
@@ -498,14 +575,16 @@ export default function OptimizeAndExportPage() {
   const resolvedServer = selectedServerEndpoint === 'auto'
     ? serverEntries.find(server => server.endpoint === autoServer?.endpoint) ?? null
     : selectedServer;
-  const resolvedOptimizeEndpoint = lockedOptimizeEndpoint ?? resolvedServer?.endpoint ?? serverEntries[0]?.endpoint ?? '';
+  const resolvedOptimizeEndpoint = lockedOptimizeEndpoint ?? resolvedServer?.endpoint ?? '';
   const autoServerStatus: ServerStatus = autoServer
     ? 'online'
     : serverEntries.some(server => server.status === 'checking')
       ? 'checking'
-      : serverEntries.some(server => server.status === 'offline')
-        ? 'offline'
-        : 'unchecked';
+      : serverEntries.some(server => server.status === 'incompatible')
+        ? 'incompatible'
+        : serverEntries.some(server => server.status === 'offline')
+          ? 'offline'
+          : 'unchecked';
   const activeServerStatus: ServerStatus = selectedServerEndpoint === 'auto'
     ? autoServerStatus
     : selectedServer?.status ?? 'unchecked';
@@ -513,6 +592,9 @@ export default function OptimizeAndExportPage() {
     ? resolvedServer?.health ?? serverEntries.find(server => server.status === 'checking' && server.health)?.health ?? null
     : selectedServer?.health ?? null;
   const hasVersionMismatch = Boolean(activeServerHealth && hasAppVersionMismatch(CURRENT_APP_VERSION, activeServerHealth.app_version));
+  const isExplicitlySelectedIncompatibleServer = selectedServerEndpoint !== 'auto'
+    && activeServerStatus === 'incompatible';
+  const canUseActiveServer = activeServerStatus === 'online' || isExplicitlySelectedIncompatibleServer;
   const isDateDataMissing = !dateData.range?.startDate || !dateData.range?.endDate || dateData.items.length === 0;
   const isPeopleDataMissing = peopleData.items.length === 0;
   const isShiftTypeDataMissing = shiftTypeData.items.length === 0 && shiftTypeData.groups.length === 0;
@@ -524,11 +606,13 @@ export default function OptimizeAndExportPage() {
     !currentJob.terminal
   );
   const isCancelling = scheduleStatus === 'cancelling';
-  const isOptimizeDisabled = isOptimizing || isRequiredDataMissing || activeServerStatus !== 'online';
+  const isOptimizeDisabled = isOptimizing || isRequiredDataMissing || !canUseActiveServer;
   const optimizeDisabledReason = isRequiredDataMissing
     ? 'Complete the missing schedule configuration before optimizing.'
-    : activeServerStatus !== 'online'
-      ? 'Backend unavailable. Check or select an online backend.'
+    : !canUseActiveServer
+      ? activeServerStatus === 'incompatible'
+        ? 'Auto found no compatible backend. Explicitly select an incompatible backend to continue anyway.'
+        : 'Backend unavailable. Check or select an online backend.'
       : null;
 
   // Create the current state object for YAML export (filtering out autogenerated items)
@@ -626,7 +710,7 @@ export default function OptimizeAndExportPage() {
         : currentServer
     )));
 
-    void fetchServerInfo(endpoint, INITIAL_HEALTH_CHECK_TIMEOUT_MS, controller.signal).then(health => {
+    void fetchServerInfo(endpoint, INITIAL_HEALTH_CHECK_TIMEOUT_MS, controller.signal).then(result => {
       const pingMs = Math.round(performance.now() - startedAt);
       setServerEntries(currentServers => currentServers.map(currentServer => {
         if (
@@ -639,9 +723,9 @@ export default function OptimizeAndExportPage() {
 
         return {
           ...currentServer,
-          status: health ? 'online' : 'offline',
-          health,
-          error: health ? null : 'Backend is not responding.',
+          status: result.status,
+          health: result.health,
+          error: result.error,
           lastCheckedAt: new Date(),
           pingMs,
         };
@@ -842,8 +926,8 @@ export default function OptimizeAndExportPage() {
       return;
     }
 
-    if (activeServerStatus !== 'online' || !resolvedOptimizeEndpoint) {
-      setErrorMessage('Select an online backend before optimizing.');
+    if (!canUseActiveServer || !resolvedOptimizeEndpoint) {
+      setErrorMessage('Select an online backend or explicitly select an incompatible backend before optimizing.');
       setSuccessMessage(null);
       return;
     }
@@ -1221,10 +1305,10 @@ export default function OptimizeAndExportPage() {
                 className="min-w-0 truncate text-sm font-medium text-gray-900"
                 editClassName="w-full border-gray-300 bg-white text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
               />
-              <span className="mt-1 block truncate text-xs text-gray-500">
+              <span className={`mt-1 block truncate text-xs ${server.status === 'incompatible' ? 'text-amber-700' : 'text-gray-500'}`}>
                 Last checked: {formatCheckedTime(server.lastCheckedAt)}
                 {server.pingMs !== null ? ` · ${server.pingMs} ms` : ''}
-                {server.error && server.error !== 'Backend is not responding.' ? ` · ${server.error}` : ''}
+                {server.status !== 'incompatible' && server.error && server.error !== 'Backend is not responding.' ? ` · ${server.error}` : ''}
               </span>
             </span>
           </label>
@@ -1283,6 +1367,8 @@ export default function OptimizeAndExportPage() {
               <FiLoader className="h-4 w-4 animate-spin" />
             ) : status === 'offline' ? (
               <FiWifiOff className="h-4 w-4" />
+            ) : status === 'incompatible' ? (
+              <FiAlertTriangle className="h-4 w-4" />
             ) : status === 'online' ? (
               <FiWifi className="h-4 w-4" />
             ) : (
@@ -1359,9 +1445,11 @@ export default function OptimizeAndExportPage() {
 
   const serverStatusClasses = activeServerStatus === 'online'
     ? 'border-green-200 bg-green-50 text-green-700'
-    : activeServerStatus === 'offline'
-      ? 'border-red-200 bg-red-50 text-red-700'
-      : 'border-gray-200 bg-gray-50 text-gray-600';
+    : activeServerStatus === 'incompatible'
+      ? 'border-amber-200 bg-amber-50 text-amber-700'
+      : activeServerStatus === 'offline'
+        ? 'border-red-200 bg-red-50 text-red-700'
+        : 'border-gray-200 bg-gray-50 text-gray-600';
   const serverStatusLabel = formatServerStatus(activeServerStatus);
 
   const runStatus = scheduleStatus
@@ -1393,6 +1481,8 @@ export default function OptimizeAndExportPage() {
               <FiWifiOff className="h-4 w-4" />
             ) : activeServerStatus === 'checking' ? (
               <FiLoader className="h-4 w-4 animate-spin" />
+            ) : activeServerStatus === 'incompatible' ? (
+              <FiAlertTriangle className="h-4 w-4" />
             ) : (
               <FiWifi className="h-4 w-4" />
             )}
@@ -1481,13 +1571,40 @@ export default function OptimizeAndExportPage() {
                 <p className="text-xs text-gray-500">Checking API endpoints...</p>
               )}
 
-              {activeServerHealth && (
+              {(activeServerHealth || activeServerStatus === 'incompatible') && (
                 <div className="space-y-2">
-                  <div className="rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
-                    <p>
-                      API version: {activeServerHealth.api_version} · Frontend version: {CURRENT_APP_VERSION} · Backend version: {activeServerHealth.app_version}
-                    </p>
-                    {hasVersionMismatch && (
+                  <div className={`rounded-md border px-3 py-2 text-xs ${activeServerStatus === 'incompatible' ? 'border-amber-200 bg-amber-50 text-amber-900' : 'border-gray-200 bg-gray-50 text-gray-600'}`}>
+                    {activeServerHealth && (
+                      <p>
+                        API version: {activeServerHealth.api_version}
+                        {activeServerStatus === 'incompatible' && activeServerHealth.api_version !== SUPPORTED_BACKEND_API_VERSION
+                          ? ` (expected ${SUPPORTED_BACKEND_API_VERSION})`
+                          : ''}
+                        {' · '}Frontend version: {CURRENT_APP_VERSION} · Backend version: {activeServerHealth.app_version}
+                      </p>
+                    )}
+                    {activeServerStatus === 'incompatible' ? (
+                      selectedServerEndpoint === 'auto' ? (
+                        <p className="font-medium">
+                          No compatible backend is available. Select a backend explicitly to continue anyway.
+                        </p>
+                      ) : (
+                        <>
+                          {!activeServerHealth && <p>Server information: invalid</p>}
+                          {activeServerHealth?.service_name !== EXPECTED_BACKEND_SERVICE_NAME && (
+                            <p className="mt-1">
+                              Service: {activeServerHealth?.service_name ?? 'missing'} (expected {EXPECTED_BACKEND_SERVICE_NAME})
+                            </p>
+                          )}
+                          {activeServerHealth?.status !== 'ready' && (
+                            <p className="mt-1">
+                              Status: {activeServerHealth?.status ?? 'missing'} (expected ready)
+                            </p>
+                          )}
+                          <p className="mt-1 font-medium">Incompatible backend. The request may fail.</p>
+                        </>
+                      )
+                    ) : hasVersionMismatch && (
                       <p className="mt-1 font-medium text-amber-700">
                         Frontend and backend versions do not match. If nothing breaks, you can continue.
                       </p>
@@ -1580,7 +1697,7 @@ export default function OptimizeAndExportPage() {
                 ) : (
                   <>
                     <FiDownload className="h-5 w-5" />
-                    Optimize and Download
+                    {isExplicitlySelectedIncompatibleServer ? 'Optimize Anyway and Download' : 'Optimize and Download'}
                   </>
                 )}
               </button>


### PR DESCRIPTION
Classify reachable backends with incompatible metadata as warnings while keeping automatic selection limited to compatible servers.

Show concise structured compatibility details after explicit selection and allow users to submit with an updated warning action.

by Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer backend status indicators for online, offline, and incompatible services.
  * Displayed detailed diagnostics when backend compatibility checks fail.
  * Added an “Optimize Anyway” option when users explicitly select an incompatible backend.

* **Bug Fixes**
  * Automatic optimization now only uses compatible, ready backends.
  * Improved handling and messaging for backend errors and invalid responses.

* **Tests**
  * Expanded coverage for backend compatibility, selection, warnings, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->