### PR TITLE
fix(docs): Remove polyfill supply chain attack

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -170,7 +170,7 @@ extra:
 
 extra_javascript:
   - assets/javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 # Ref: https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/#copyright-notice


### PR DESCRIPTION
Without this fix, local dev preview will be redirected to https://polyfill.io/v3/polyfill.min.js?features=es6 , with the following message:

```
This site is asking you to sign in. Warning: Your login information will be shared with polyfill.io, not the website you are currently visiting.
```

<img width="817" height="493" alt="Screenshot from 2026-08-08 22-39-00" src="https://github.com/user-attachments/assets/d5fcb2e4-85e5-4e6b-ab30-1fe1fb9388f6" />

Ref: https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MathJax polyfill source to use a cdnjs-hosted URL, improving reliability and availability of mathematical notation rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->