### PR TITLE
fix(sentry): Ignore 404 to suppress bot-scan noise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ Before modifying `core/` or `web-frontend/`, read its `AGENTS.md`.
   `feat(core/serve): ...`, `fix(web-frontend): ...`, or `docs: ...`.
 - For Codex-created commits, include a descriptive body that ends with a
   separate `by Codex` line.
+- Build multi-paragraph commit messages with separate `git commit -m`
+  arguments. Do not embed escaped `\n` sequences because Git stores them
+  literally instead of converting them to newlines.
 
 ## Comment and Documentation Style
 - Keep comments and documentation minimal, concise, yet informative.

--- a/core/nurse_scheduling/sentry.py
+++ b/core/nurse_scheduling/sentry.py
@@ -96,6 +96,9 @@ def capture_optimize_exception(job: "Job", content: bytes, error: Exception) -> 
 def capture_invalid_request(request: Request, status_code: int, detail: Any) -> None:
     if not _should_enable_sentry():
         return
+    # Missing routes and expired resources are expected and not actionable.
+    if status_code == 404:
+        return
 
     import sentry_sdk
 

--- a/core/tests/test_sentry.py
+++ b/core/tests/test_sentry.py
@@ -23,6 +23,8 @@ import sys
 import types
 from datetime import datetime, timezone
 
+import pytest
+
 from nurse_scheduling.loader import _load_yaml
 from nurse_scheduling.sentry import capture_invalid_request, capture_optimize_exception, init_sentry
 from nurse_scheduling.server.jobs.models import Job, JobRequest, JobState
@@ -266,3 +268,19 @@ def test_capture_invalid_request_records_route_context_and_fingerprint(monkeypat
         )
     ]
     assert scope.fingerprint == ["invalid-request", "422", "/optimize/{job_id}"]
+
+
+@pytest.mark.parametrize("route", [None, types.SimpleNamespace(path="/optimize/{job_id}")])
+def test_capture_invalid_request_ignores_not_found(monkeypatch, route):
+    request = types.SimpleNamespace(
+        scope={"route": route},
+        url=types.SimpleNamespace(path="/optimize/missing"),
+        method="GET",
+    )
+    fake_sentry_sdk = types.SimpleNamespace(
+        new_scope=lambda: pytest.fail("404 response reached Sentry"),
+    )
+    monkeypatch.setattr("nurse_scheduling.sentry._should_enable_sentry", lambda: True)
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake_sentry_sdk)
+
+    capture_invalid_request(request, 404, "Not Found")

--- a/core/tests/test_serve.py
+++ b/core/tests/test_serve.py
@@ -29,6 +29,7 @@ import threading
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
@@ -246,7 +247,7 @@ def _wait_for_terminal(
     client: TestClient,
     job_id: str,
     timeout: float = PROCESS_START_TIMEOUT_SECONDS,
-) -> dict:
+) -> dict[str, Any]:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         response = client.get(f"/optimize/{job_id}")

--- a/core/tests/test_serve.py
+++ b/core/tests/test_serve.py
@@ -242,8 +242,13 @@ def _create(client: TestClient, **data):
     return client.post("/optimize", data={"yaml_content": "apiVersion: alpha\n", **data})
 
 
-def _wait_for_terminal(client: TestClient, job_id: str) -> dict:
-    for _ in range(300):
+def _wait_for_terminal(
+    client: TestClient,
+    job_id: str,
+    timeout: float = PROCESS_START_TIMEOUT_SECONDS,
+) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
         response = client.get(f"/optimize/{job_id}")
         assert response.status_code == 200
         body = response.json()

--- a/web-frontend/e2e/rename-save-load-roundtrip.spec.ts
+++ b/web-frontend/e2e/rename-save-load-roundtrip.spec.ts
@@ -20,7 +20,7 @@
 // This test is mostly AI generated.
 
 import { expect, test } from './test';
-import { disableModalDialogs, seedSchedulingState } from './helpers';
+import { seedSchedulingState } from './helpers';
 
 test('renamed people and groups survive a save-load roundtrip', async ({ page }) => {
   /*
@@ -28,9 +28,8 @@ test('renamed people and groups survive a save-load roundtrip', async ({ page })
    * 1. Confirm the original person and group names are visible before renaming.
    * 2. Rename both through the real People page UI.
    * 3. Capture the resulting YAML from Save and Load.
-   * 4. Upload that YAML back and confirm the renamed references persist.
+   * 4. Upload that YAML back, wait for completion, and confirm the renamed references persist.
    */
-  await disableModalDialogs(page);
   await seedSchedulingState(page, {
     apiVersion: 'test',
     description: 'rename roundtrip seed',
@@ -70,11 +69,25 @@ test('renamed people and groups survive a save-load roundtrip', async ({ page })
   await expect(page.locator('pre')).toContainText('Team Omega');
   const yamlText = await page.locator('pre').textContent();
 
+  const uploadCompleted = new Promise<void>((resolve, reject) => {
+    page.on('dialog', async dialog => {
+      try {
+        const isSuccessDialog = dialog.message().includes('YAML file loaded successfully!');
+        await dialog.accept();
+        if (isSuccessDialog) {
+          resolve();
+        }
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
   await page.locator('input[type="file"]').setInputFiles({
     name: 'rename-roundtrip.yaml',
     mimeType: 'application/x-yaml',
     buffer: Buffer.from(yamlText ?? '', 'utf8'),
   });
+  await uploadCompleted;
 
   await page.goto('/shift-requests');
   await expect(page.getByText('Person: P1X')).toBeVisible();

--- a/web-frontend/e2e/rename-save-load-roundtrip.spec.ts
+++ b/web-frontend/e2e/rename-save-load-roundtrip.spec.ts
@@ -74,11 +74,16 @@ test('renamed people and groups survive a save-load roundtrip', async ({ page })
       try {
         const message = dialog.message();
         const isSuccessDialog = message.includes('YAML file loaded successfully!');
+        const isVersionWarningDialog = message.startsWith('Dirty app version detected.')
+          || message.startsWith('App version mismatch detected.')
+          || message.startsWith('The loaded file does not contain app version information.');
         await dialog.accept();
         if (isSuccessDialog) {
           resolve();
         } else if (message.startsWith('Error loading YAML file:')) {
           reject(new Error(message));
+        } else if (!isVersionWarningDialog) {
+          reject(new Error(`Unhandled dialog appeared: ${message}`));
         }
       } catch (error) {
         reject(error);

--- a/web-frontend/e2e/rename-save-load-roundtrip.spec.ts
+++ b/web-frontend/e2e/rename-save-load-roundtrip.spec.ts
@@ -72,10 +72,13 @@ test('renamed people and groups survive a save-load roundtrip', async ({ page })
   const uploadCompleted = new Promise<void>((resolve, reject) => {
     page.on('dialog', async dialog => {
       try {
-        const isSuccessDialog = dialog.message().includes('YAML file loaded successfully!');
+        const message = dialog.message();
+        const isSuccessDialog = message.includes('YAML file loaded successfully!');
         await dialog.accept();
         if (isSuccessDialog) {
           resolve();
+        } else if (message.startsWith('Error loading YAML file:')) {
+          reject(new Error(message));
         }
       } catch (error) {
         reject(error);


### PR DESCRIPTION
> Judgment:
> 
> - PRs #50 (https://github.com/j3soon/nurse-scheduling/pull/50), #56 (https://github.com/j3soon/nurse-scheduling/pull/56), and #73
>   (https://github.com/j3soon/nurse-scheduling/pull/73) only suppress unmatched bot probes.
> 
> - #77 (https://github.com/j3soon/nurse-scheduling/pull/77) centrally filters unmatched routes but still reports expired jobs.
> - #74 (https://github.com/j3soon/nurse-scheduling/pull/74) and #75 (https://github.com/j3soon/nurse-scheduling/pull/75) only handle missing jobs. #74
>   also accidentally logs 404s as server exceptions.
> 
> - I chose the central policy proposed by #53 (https://github.com/j3soon/nurse-scheduling/pull/53): all current 404s represent missing routes or expected
>   missing/expired resources and are not actionable. Other 4xx reporting remains unchanged.
>
> -- by Codex

Closes: #50, #53, #56, #73, #74, #75, #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 404 invalid requests are no longer reported to Sentry, reducing unnecessary error alerts.
  - Other invalid request reporting remains unchanged.

- **Reliability**
  - Terminal job checks now support configurable timeouts for more consistent execution.
  - Saving and reloading scheduling data now waits more reliably for upload completion and successful YAML loading, with clearer handling of load errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->