### PR TITLE
fix(web-frontend): limit development notice to non-release builds

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,10 +33,4 @@ The build selector at the lower right switches between available app builds.
 See [Screen and Control Reference](user-guide/reference.md) for shared controls,
 keyboard shortcuts, weights, and automatic entries.
 
-!!! warning "Active development"
-
-    Breaking changes can occur. Back up each useful schedule as YAML and check
-    the [privacy and data-handling guidance](user-guide/save-and-load.md#download-anonymized-yaml)
-    before entering real information.
-
 Developers and operators can use the [Developer Guide](developer-guide/index.md).

--- a/web-frontend/src/app/page.tsx
+++ b/web-frontend/src/app/page.tsx
@@ -26,7 +26,13 @@ import { FiChevronDown, FiCheck } from 'react-icons/fi';
 import PageDocumentationLink from '@/components/PageDocumentationLink';
 import { useSchedulingData } from '@/hooks/useSchedulingData';
 import { DOCUMENTATION_URLS, STATIC_BUILD_URLS } from '@/constants/urls';
-import { areBuildOriginsEquivalent, fetchReleaseBranches, BuildEntry } from '@/utils/version';
+import {
+  areBuildOriginsEquivalent,
+  BuildEntry,
+  CURRENT_APP_VERSION,
+  fetchReleaseBranches,
+  isStableReleaseVersion,
+} from '@/utils/version';
 
 export default function Home() {
   const router = useRouter();
@@ -105,12 +111,13 @@ export default function Home() {
         <p className="text-lg text-gray-600 mb-4">
           Welcome to the Nurse Scheduling System. Use the tabs above to navigate.
         </p>
-        <div className="mb-8 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
-          <p className="text-sm text-yellow-800">
-            ⚠️ This project is in active development. Breaking changes may occur without notice. Please proceed with caution.
-          </p>
-        </div>
-
+        {!isStableReleaseVersion(CURRENT_APP_VERSION) && (
+          <div className="mb-8 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+            <p className="text-sm text-blue-800">
+              This is a development build. For best compatibility with saved YAML, use a versioned release.
+            </p>
+          </div>
+        )}
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <button
             onClick={handleStartNew}

--- a/web-frontend/src/utils/version.test.ts
+++ b/web-frontend/src/utils/version.test.ts
@@ -25,6 +25,7 @@ import {
   fetchLatestTag,
   fetchReleaseBranches,
   getMajorMinor,
+  isStableReleaseVersion,
   parseVersionParts,
 } from '@/utils/version';
 
@@ -49,6 +50,15 @@ describe('version utils', () => {
     expect(getMajorMinor('v1.2.3-4-gabcd')).toBe('v1.2');
     expect(getMajorMinor('2.7.0')).toBeNull();
     expect(getMajorMinor('invalid')).toBeNull();
+  });
+
+  it('recognizes only clean version tags as stable releases', () => {
+    expect(isStableReleaseVersion('v1.2.3')).toBe(true);
+    expect(isStableReleaseVersion('v1.2.3-4-gabcdef0')).toBe(false);
+    expect(isStableReleaseVersion('v1.2.3-dirty')).toBe(false);
+    expect(isStableReleaseVersion('deadbeef')).toBe(false);
+    expect(isStableReleaseVersion('dev')).toBe(false);
+    expect(isStableReleaseVersion('unknown')).toBe(false);
   });
 
   it('parses git describe version parts for display and comparison', () => {

--- a/web-frontend/src/utils/version.ts
+++ b/web-frontend/src/utils/version.ts
@@ -55,6 +55,10 @@ const HASH_ONLY_PATTERN = /^[0-9a-fA-F]{7,}$/;
 const TAGGED_COMMIT_PATTERN = /^(v\d+\.\d+\.\d+)-(\d+)-g([0-9a-fA-F]{7,})$/;
 const TAG_PATTERN = /^v(\d+)\.(\d+)\.(\d+)$/;
 
+export function isStableReleaseVersion(version: string): boolean {
+  return TAG_PATTERN.test(version);
+}
+
 export function parseVersionParts(version: string): VersionParts {
   const isDirty = version.endsWith('-dirty');
   const cleanVersion = isDirty ? version.slice(0, -'-dirty'.length) : version;


### PR DESCRIPTION
Remove the unconditional documentation warning and show concise YAML compatibility guidance on the home page only for builds that are not clean version tags.

Treat exact vMAJOR.MINOR.PATCH versions as stable releases while keeping dirty, commit-ahead, hash-only, development, and unknown builds visible.

by Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version-aware messaging on the home page.
  * Development builds now display guidance to use a versioned release for best compatibility with saved YAML.
* **Bug Fixes**
  * Stable releases no longer show the development-build notice.
* **Documentation**
  * Removed the active-development warning from the documentation index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->